### PR TITLE
Fix recent bug in XActivityRestriction

### DIFF
--- a/src/biz/bokhorst/xprivacy/XActivityRestriction.java
+++ b/src/biz/bokhorst/xprivacy/XActivityRestriction.java
@@ -81,7 +81,8 @@ public class XActivityRestriction extends Activity {
 
 		@Override
 		protected List<XApplicationInfo> doInBackground(String... params) {
-			return XApplicationInfo.getXApplicationList(XActivityRestriction.this, params[0]);
+			mRestrictionName = params[0];
+			return XApplicationInfo.getXApplicationList(XActivityRestriction.this, mRestrictionName);
 		}
 
 		@Override


### PR DESCRIPTION
The field mRestrictionName wasn't set and as a result the activity didn't function properly.
