### PR TITLE
Slovenian translation updated (and also 1 question)

### DIFF
--- a/res/values-sl/strings.xml
+++ b/res/values-sl/strings.xml
@@ -19,7 +19,7 @@
     <string name="menu_theme">Spremeni temo</string>
     <string name="menu_pro">Pro različica</string>
     <string name="menu_about">O programu</string>
-    <string name="menu_help">Help</string>
+    <string name="menu_help">Pomoč</string>
     <string name="menu_all">Vse</string>
     <string name="menu_clear">Počisti</string>
     <string name="menu_app_launch">Zaženi</string>
@@ -61,10 +61,10 @@
     <string name="restrict_view">Pogled (brskalnik)</string>
     <string name="title_category">Kategorija:</string>
     <string name="title_restrict">Označi za omejitev pravic:</string>
-    <string name="title_nofilter">No active filter</string>
+    <string name="title_nofilter">Ni aktivnih filtrov</string>
     <plurals name="title_filters">
-        <item quantity="one">1 active filter</item>
-        <item quantity="other">%d active filters</item>
+        <item quantity="one">1 aktiven filter</item>
+        <item quantity="other">%d aktivnih filtrov</item>
     </plurals>
     <string name="settings_serial">Serijska št.</string>
     <string name="settings_lat">Geografska širina</string>


### PR DESCRIPTION
Hi! Just one question. The slovenian language doesn't just have a singular and plural(i.e. 1 item is "1 element", 2 items is "2 elementa", 3 and 4 items are "3 in 4 elementi", 5 items and more is "5 elementov"). So, can I just add

&lt;item quantity="two"&gt;2 aktivna filtra&lt;/item&gt;
&lt;item quantity="three"&gt;3 aktivni filtri&lt;/item&gt;
&lt;item quantity="four"&gt;4 aktivni filtri&lt;/item&gt;

into the strings.xml between &lt;item quantity="one"&gt;1 aktiven filter&lt;/item&gt; and &lt;item quantity="other"&gt;%d aktivnih filtrov&lt;/item&gt; ?
