### PR TITLE
Fixed margins on large screens

### DIFF
--- a/res/layout/mainlist.xml
+++ b/res/layout/mainlist.xml
@@ -16,7 +16,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="4dp"
-        android:layout_marginRight="@dimen/activity_vertical_margin"
+        android:layout_marginRight="@dimen/activity_horizontal_margin"
         android:background="?attr/drawable_card"
         android:orientation="vertical"
         android:paddingBottom="6dp"
@@ -203,7 +203,7 @@
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginRight="@dimen/activity_vertical_margin" >
+        android:layout_marginRight="@dimen/activity_horizontal_margin" >
 
         <TextView
             android:layout_width="wrap_content"
@@ -243,6 +243,7 @@
         android:id="@+id/lvApp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginRight="@dimen/activity_horizontal_margin_list"
         android:layout_marginTop="6dip"
         android:choiceMode="multipleChoice"
         android:fastScrollEnabled="true"

--- a/res/values-sw720dp-land/dimens.xml
+++ b/res/values-sw720dp-land/dimens.xml
@@ -5,5 +5,6 @@
          screen margins) for sw720dp devices (e.g. 10" tablets) in landscape here.
     -->
     <dimen name="activity_horizontal_margin">128dp</dimen>
+    <dimen name="activity_horizontal_margin_list">106dp</dimen>
 
 </resources>

--- a/res/values/dimens.xml
+++ b/res/values/dimens.xml
@@ -3,5 +3,6 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
+    <dimen name="activity_horizontal_margin_list">0dp</dimen>
 
 </resources>


### PR DESCRIPTION
When I added the filter frame a couple of commits before, I mixed horizontal and vertical margins resulting in a displacement for larges screens in landscape mode :

![tab_before](https://f.cloud.github.com/assets/3890441/1020470/a4c37afa-0ca4-11e3-8a9d-afc86bd26d12.jpg)

Now it's fixed, and I added a custom margin for the list in order to align the list with the rest of the gui.

![tab_after](https://f.cloud.github.com/assets/3890441/1020471/c9683076-0ca4-11e3-9c82-4c1ea41d80e2.jpg)
