### PR TITLE
Fixed "full-tick diplayed when checking an app in main activity but dang...

### DIFF
--- a/src/biz/bokhorst/xprivacy/ActivityMain.java
+++ b/src/biz/bokhorst/xprivacy/ActivityMain.java
@@ -1392,7 +1392,7 @@ public class ActivityMain extends Activity implements OnItemSelectedListener, Co
 							for (String restrictionName : listRestriction)
 								PrivacyManager.setRestricted(null, view.getContext(), xAppInfo.getUid(),
 										restrictionName, null, allRestricted);
-							holder.imgCBName.setImageResource(allRestricted ? R.drawable.checkbox_check
+							holder.imgCBName.setImageResource(allRestricted ? R.drawable.checkbox_half
 									: android.R.color.transparent);
 						}
 					});


### PR DESCRIPTION
...erous were not ticked"

Now it displays a half-tick when you tick an app in the main activity, until you go into the app details and you tick all the dangerous restrictions.
