### PR TITLE
Update for fix "full-tick diplayed when checking an app in main activity...

### DIFF
--- a/src/biz/bokhorst/xprivacy/ActivityMain.java
+++ b/src/biz/bokhorst/xprivacy/ActivityMain.java
@@ -1392,8 +1392,11 @@ public class ActivityMain extends Activity implements OnItemSelectedListener, Co
 							for (String restrictionName : listRestriction)
 								PrivacyManager.setRestricted(null, view.getContext(), xAppInfo.getUid(),
 										restrictionName, null, allRestricted);
-							holder.imgCBName.setImageResource(allRestricted ? R.drawable.checkbox_half
-									: android.R.color.transparent);
+							holder.imgCBName.setEnabled(!(allRestricted && mRestrictionName == null));
+							holder.imgCBName
+									.setImageResource(allRestricted ? (mRestrictionName == null ? R.drawable.checkbox_half
+											: R.drawable.checkbox_check)
+											: android.R.color.transparent);
 						}
 					});
 				}


### PR DESCRIPTION
... but dangerous were not ticked"

It corrects an issue by preventing to untick a half-ticked checkbox that you just ticked before.
And when the permission filter is activated, it shows a normal tick in the checkbox instead of a half-tick when you tick the checkbox.
