### PR TITLE
Grouped items in app details activity's menu

### DIFF
--- a/res/menu/app.xml
+++ b/res/menu/app.xml
@@ -23,14 +23,20 @@
         android:title="@string/menu_fetch"
         android:visible="true"/>
     <item
-        android:id="@+id/menu_app_launch"
-        android:title="@string/menu_app_launch"/>
-    <item
-        android:id="@+id/menu_app_settings"
-        android:title="@string/menu_app_settings"/>
-    <item
-        android:id="@+id/menu_app_store"
-        android:title="@string/menu_app_store"/>
+        android:id="@+id/menu_application"
+        android:title="@string/help_application">
+        <menu>
+            <item
+                android:id="@+id/menu_app_launch"
+                android:title="@string/menu_app_launch"/>
+            <item
+                android:id="@+id/menu_app_settings"
+                android:title="@string/menu_app_settings"/>
+            <item
+                android:id="@+id/menu_app_store"
+                android:title="@string/menu_app_store"/>
+        </menu>
+    </item>
     <item
         android:id="@+id/menu_accounts"
         android:title="@string/menu_accounts"/>


### PR DESCRIPTION
Grouped 'Launch', 'App info' and 'PlayStore' into a submenu in order not to be forced to scroll
