### PR TITLE
Export progress

### DIFF
--- a/src/biz/bokhorst/xprivacy/ActivityMain.java
+++ b/src/biz/bokhorst/xprivacy/ActivityMain.java
@@ -1,6 +1,7 @@
 package biz.bokhorst.xprivacy;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;


### PR DESCRIPTION
Even on my (fairly) fast phone, when I choose Export, there is a longish pause with very little visual indication of progress, while it says "Export: Loading".

This adds periodic progress reporting for this phase.

The functions getSettings(context) and getRestricted(context) in PrivacyManager are now unused.
