### PR TITLE
Filters message tweak & tutorial opens filter tab

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -133,8 +133,8 @@ however it is impossible to guarantee it will work flawlessly on each and every 
     <string name="help_restricted">restrictions are changed</string>
     <string name="help_shared">restrictions are submitted</string>
     <string name="fingerprint" translatable="false">10620ae961d78854f6c9cd872c4388232849c799</string>
-    <string name="tutorial_mainheader" translatable="false">Select the category to restrict
-\nFilter visible applications</string>
+    <string name="tutorial_mainheader" translatable="false">Select the category to restrict\n
+\nChoose which apps to see with the filters</string>
     <string name="tutorial_mainlist" translatable="false">Tap a check box to restrict the selected category for an application\n
 \nApplications will be fed empty or fake data for restricted categories\n
 \nTap the application icon for detailed restrictions and settings</string>

--- a/src/biz/bokhorst/xprivacy/ActivityMain.java
+++ b/src/biz/bokhorst/xprivacy/ActivityMain.java
@@ -816,6 +816,8 @@ public class ActivityMain extends Activity implements OnItemSelectedListener, Co
 	}
 
 	private void optionTutorial() {
+		if (mFiltersHidden)
+			toggleFiltersVisibility();
 		((RelativeLayout) findViewById(R.id.rlTutorialHeader)).setVisibility(View.VISIBLE);
 		((RelativeLayout) findViewById(R.id.rlTutorialDetails)).setVisibility(View.VISIBLE);
 		PrivacyManager.setSetting(null, this, 0, PrivacyManager.cSettingTutorialMain, Boolean.FALSE.toString());

--- a/tools/addstring.sh
+++ b/tools/addstring.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-grep -RIl "\<string name=\"menu_contacts" . | xargs sed -i -e '/string name="menu_contacts/a \
-\ \ \ \ <string name="menu_tutorial">Tutorial</string>'
+#grep -RIl "\<string name=\"menu_contacts" . | xargs sed -i -e '/string name="menu_contacts/a \
+#\ \ \ \ <string name="menu_tutorial">Tutorial</string>'
 
 #grep -RIl "\<string name=\"msg_edit" . | xargs sed -i -e '/msg_edit/d'
+
+grep -RIl "\<string name=\"app_name" res | xargs -L1 sed -i -e 's/Filter visible applications/Choose which apps to see with the filters/'


### PR DESCRIPTION
I made optionTutorial open the filters tab if it wasn't already open. This ensures that the tutorial text has enough space to display.

I also changed the tutorial text for the filters.

Another option might be to change the ok button text to "next" and display a second message onclick. I could imagine the tutorial opening the category tab, covering only the bit underneath the tab, and then on next, opening the filters tab. That way there would even be space to say that the "clear" and "toggle" menu options respect the filters.
