### PR TITLE
Proper sorting for app info in ApplicationInfoEx

### DIFF
--- a/src/biz/bokhorst/xprivacy/ApplicationInfoEx.java
+++ b/src/biz/bokhorst/xprivacy/ApplicationInfoEx.java
@@ -101,7 +101,6 @@ public class ApplicationInfoEx implements Comparable<ApplicationInfoEx> {
 		for (String version : this.getPackageVersion(context))
 			if (!listVersion.contains(version))
 				listVersion.add(version);
-		Collections.sort(listVersion);
 		return TextUtils.join(",  ", listVersion);
 	}
 


### PR DESCRIPTION
TreeMaps are sorted by key. treemap.values() gives a list of values, sorted by their keys.
My context menus for apps sharing uids could muddle apps up without something like this.
