### PR TITLE
let xposeddescription be translatable

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -42,7 +42,7 @@
             android:value="42+" />
         <meta-data
             android:name="xposeddescription"
-            android:value="The ultimate privacy manager" />
+            android:value="@string/xposed_summary" />
 
         <!-- Google Play services -->
         <meta-data

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -131,6 +131,7 @@
 \n点击应用图标以查看详细权限限制规则和设置</string>
     <string name="tutorial_detailsheader">点击应用图标以查看更多操作</string>
     <string name="tutorial_detailslist">点击左侧向下的箭头以查看该类别的子权限</string>
+    <string name="xposed_summary">终级隐私管理器</string>
 
 </resources>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -143,5 +143,6 @@ however it is impossible to guarantee it will work flawlessly on each and every 
 \nTap the app icon for detailed restrictions and settings</string>
     <string name="tutorial_detailsheader">Tap the app icon for more actions</string>
     <string name="tutorial_detailslist">Tap the down arrow to see the function exceptions of a restriction category</string>
+    <string name="xposed_summary">The ultimate privacy manager</string>
 
 </resources>


### PR DESCRIPTION
Currently, the `xposeddescription` in xposed framework is not translatable.
This commit let it be translatable, and provides simplified chinese translation.
