### PR TITLE
update simplified chinese translation, shorter for filter, longer for help.

### DIFF
--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -86,13 +86,13 @@
         <item quantity="other">%d个已启用的过滤器</item>
     </plurals>
 
-    <string name="title_fused">曾使用当前选中权限的应用</string>
-    <string name="title_finternet">含有联网权限的应用</string>
-    <string name="title_fpermission">仅显示应用已申请的权限</string>
-    <string name="title_frestricted">仅显示已限制权限的应用</string>
-    <string name="title_fuser">仅显示用户应用</string>
-    <string name="title_fsystem">仅显示系统应用</string>
-    <string name="title_fnot">反选</string>
+    <string name="title_fused">曾经使用</string>
+    <string name="title_finternet">网络权限</string>
+    <string name="title_fpermission">含有权限</string>
+    <string name="title_frestricted">限制使用</string>
+    <string name="title_fuser">用户应用</string>
+    <string name="title_fsystem">系统应用</string>
+    <string name="title_fnot">←反选</string>
     <string name="settings_serial">序列号</string>
     <string name="settings_lat">纬度</string>
     <string name="settings_lon">经度</string>
@@ -116,13 +116,13 @@
     <string name="settings_confidence">最大采样置信区间</string>
     <string name="settings_experimental">实验性功能</string>
     <string name="help_application">请输入应用名称</string>
-    <string name="help_internet">应用含有联网权限</string>
-    <string name="help_granted">应用已申请的权限（ Androidmanifest 中表明）</string>
-    <string name="help_used">应用曾使用的权限</string>
-    <string name="help_used_grayed">no usage data available</string>
-    <string name="help_frozen">应用已被冻结/停用</string>
+    <string name="help_internet">应用含有网络访问权限</string>
+    <string name="help_granted">应用已经含有这种权限</string>
+    <string name="help_used">应用曾经用过这种权限</string>
+    <string name="help_used_grayed">应用没有用过这种权限</string>
+    <string name="help_frozen">应用已被暂停使用</string>
     <string name="help_dangerous">可能导致应用异常的权限</string>
-    <string name="help_half">已限制部分权限</string>
+    <string name="help_half">只限制部分权限</string>
     <string name="help_attention">可以下载限制规则的应用</string>
     <string name="help_restricted">限制规则已经生效的应用</string>
     <string name="help_shared">已经分享限制规则的应用</string>


### PR DESCRIPTION
CC privious translators, please review it.
@JMsoft, @Tungstwenty, @jpeg729, @pyler, @tonymanou

@M66B, please wait for the contributor's response before merge (If you decide to merge).
Although I think its better than current translation, however, I think we should wait for response from other contributor.

For filter screen, it should be short and clear (So I short translation). Otherwise, small screen phone cannot display them (which is single line).
For help screen, it should have more details (So I add more details).

This commits fixes the wrong translation for `help_granted` (Not every restriction in xprivacy is through `AndroidManifest.xml`, for example, serial number, proc, build.prop, ... etc).
