### PR TITLE
call `setTheme` before `super.onCreate`

### DIFF
--- a/src/biz/bokhorst/xprivacy/ActivityApp.java
+++ b/src/biz/bokhorst/xprivacy/ActivityApp.java
@@ -107,12 +107,12 @@ public class ActivityApp extends Activity {
 	}
 
 	public void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-
 		// Set theme
 		String themeName = PrivacyManager.getSetting(null, this, 0, PrivacyManager.cSettingTheme, "", false);
 		mThemeId = (themeName.equals("Dark") ? R.style.CustomTheme : R.style.CustomTheme_Light);
 		setTheme(mThemeId);
+
+		super.onCreate(savedInstanceState);
 
 		// Set layout
 		setContentView(R.layout.restrictionlist);

--- a/src/biz/bokhorst/xprivacy/ActivityMain.java
+++ b/src/biz/bokhorst/xprivacy/ActivityMain.java
@@ -117,8 +117,6 @@ public class ActivityMain extends Activity implements OnItemSelectedListener, Co
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-
 		// Salt should be the same when exporting/importing
 		String salt = PrivacyManager.getSetting(null, this, 0, PrivacyManager.cSettingSalt, null, false);
 		if (salt == null) {
@@ -132,6 +130,8 @@ public class ActivityMain extends Activity implements OnItemSelectedListener, Co
 		String themeName = PrivacyManager.getSetting(null, this, 0, PrivacyManager.cSettingTheme, "", false);
 		mThemeId = (themeName.equals("Dark") ? R.style.CustomTheme : R.style.CustomTheme_Light);
 		setTheme(mThemeId);
+
+		super.onCreate(savedInstanceState);
 
 		// Set layout
 		setContentView(R.layout.mainlist);

--- a/src/biz/bokhorst/xprivacy/ActivityUsage.java
+++ b/src/biz/bokhorst/xprivacy/ActivityUsage.java
@@ -56,12 +56,12 @@ public class ActivityUsage extends Activity {
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-
 		// Set theme
 		String themeName = PrivacyManager.getSetting(null, this, 0, PrivacyManager.cSettingTheme, "", false);
 		mThemeId = (themeName.equals("Dark") ? R.style.CustomTheme : R.style.CustomTheme_Light);
 		setTheme(mThemeId);
+
+		super.onCreate(savedInstanceState);
 
 		// Set layout
 		setContentView(R.layout.usagelist);


### PR DESCRIPTION
It's optional for ics+, however, I'm glad if you can merge it, which
will fix possibble conflict in following back-porting.

The custom theme won't apply after the call of `super.onCreate`.
It seems a bug in Android 2.3, and ICS+ fixes it.
For more information, please visit:
https://code.google.com/p/android/issues/detail?id=4394
