### PR TITLE
set the mininal sdk in meta.xml to 10

### DIFF
--- a/assets/meta.xml
+++ b/assets/meta.xml
@@ -13,7 +13,7 @@
     <Hook restriction="accounts" method="getTokenWithNotificationGoogle" permissions="GET_ACCOUNTS" sdk="10" />
 
     <Hook restriction="browser" method="BrowserProvider" permissions="READ_HISTORY_BOOKMARKS,GLOBAL_SEARCH" sdk="10" />
-    <Hook restriction="browser" method="BrowserProvider2" permissions="READ_HISTORY_BOOKMARKS,GLOBAL_SEARCH" sdk="10" />
+    <Hook restriction="browser" method="BrowserProvider2" permissions="READ_HISTORY_BOOKMARKS,GLOBAL_SEARCH" sdk="14" />
 
     <Hook restriction="calendar" method="CalendarProvider2" permissions="READ_CALENDAR" sdk="10" />
 
@@ -110,7 +110,7 @@
     <Hook restriction="messages" method="SmsProvider" permissions="READ_SMS" sdk="10" />
     <Hook restriction="messages" method="MmsProvider" permissions="READ_SMS" sdk="10" />
     <Hook restriction="messages" method="MmsSmsProvider" permissions="READ_SMS" sdk="10" />
-    <Hook restriction="messages" method="VoicemailContentProvider" permissions="READ_WRITE_ALL_VOICEMAIL" sdk="10" />
+    <Hook restriction="messages" method="VoicemailContentProvider" permissions="READ_WRITE_ALL_VOICEMAIL" sdk="14" />
     <Hook restriction="messages" method="android.intent.action.DATA_SMS_RECEIVED" permissions="RECEIVE_SMS" sdk="19" />
     <Hook restriction="messages" method="android.provider.Telephony.SMS_RECEIVED" permissions="RECEIVE_SMS" sdk="19" />
     <Hook restriction="messages" method="android.provider.Telephony.WAP_PUSH_RECEIVED" permissions="RECEIVE_WAP_PUSH" sdk="19" />
@@ -126,7 +126,7 @@
     <Hook restriction="network" method="getScanResults" permissions="ACCESS_WIFI_STATE" sdk="10" />
     <Hook restriction="network" method="getWifiApConfiguration" permissions="ACCESS_WIFI_STATE" sdk="10" />
 
-    <Hook restriction="nfc" method="getNfcAdapter" permissions="NFC" sdk="10" />
+    <Hook restriction="nfc" method="getNfcAdapter" permissions="NFC" sdk="14" />
     <Hook restriction="nfc" method="android.nfc.action.ADAPTER_STATE_CHANGED" permissions="NFC" sdk="18" />
     <Hook restriction="nfc" method="android.nfc.action.NDEF_DISCOVERED" permissions="NFC" sdk="10" />
     <Hook restriction="nfc" method="android.nfc.action.TAG_DISCOVERED" permissions="NFC" sdk="10" />
@@ -141,12 +141,12 @@
     <Hook restriction="overlay" method="updateViewLayout" permissions="SYSTEM_ALERT_WINDOW" sdk="1" />
 
     <Hook restriction="phone" method="getDeviceId" permissions="READ_PHONE_STATE" sdk="10" />
-    <Hook restriction="phone" method="getIsimDomain" permissions="READ_PHONE_STATE" sdk="10" />
-    <Hook restriction="phone" method="getIsimImpi" permissions="READ_PHONE_STATE" sdk="10" />
-    <Hook restriction="phone" method="getIsimImpu" permissions="READ_PHONE_STATE" sdk="10" />
+    <Hook restriction="phone" method="getIsimDomain" permissions="READ_PHONE_STATE" sdk="14" />
+    <Hook restriction="phone" method="getIsimImpi" permissions="READ_PHONE_STATE" sdk="14" />
+    <Hook restriction="phone" method="getIsimImpu" permissions="READ_PHONE_STATE" sdk="14" />
     <Hook restriction="phone" method="getLine1AlphaTag" permissions="READ_PHONE_STATE" sdk="10" />
     <Hook restriction="phone" method="getLine1Number" permissions="READ_PHONE_STATE" sdk="10" />
-    <Hook restriction="phone" method="getMsisdn" permissions="READ_PHONE_STATE" sdk="10" />
+    <Hook restriction="phone" method="getMsisdn" permissions="READ_PHONE_STATE" sdk="14" />
     <Hook restriction="phone" method="getSimSerialNumber" permissions="READ_PHONE_STATE" sdk="10" />
     <Hook restriction="phone" method="getSubscriberId" permissions="READ_PHONE_STATE" sdk="10" />
     <Hook restriction="phone" method="getVoiceMailAlphaTag" permissions="READ_PHONE_STATE" sdk="10" />


### PR DESCRIPTION
Note for these methods:
getAuthToken: one of them requires api-14+, other are ok
startRecording: one of them requires api-16+, other are ok

Not for these action:
PACKAGE_VERIFIED: set to api-17+
http://developer.android.com/reference/android/content/Intent.html#ACTION_PACKAGE_VERIFIED

Unsure for these methods: (didn't find in android's public api, please help to check, I will check it more carefully)
getTokenGoogle
getTokenWithNotificationGoogle
BrowserProvider
BrowserProvider2
CalendarProvider2
contacts/contacts
contacts/data
contacts/raw_contacts
contacts/phone_lookup
contacts/profile
UserDictionary
EMailProvider
%hostname
%imei
%macaddr
%serialno
%cid
/proc
/system/build.prop
/sys/block/.../cid
/sys/class/.../cid
AdvertisingId
GservicesProvider
SERIAL
inet
disableLocationUpdates
enableLocationUpdates
getAllMessagesFromIcc
SmsProvider
MmsProvider
MmsSmsProvider
VoicemailContentProvider
getWifiApConfiguration
getNfcAdapter
com.google.android.c2dm.intent.REGISTRATION
com.google.android.c2dm.intent.RECEIVE
getIsimDomain
getIsimImpi
getIsimImpu
getLine1AlphaTag
getMsisdn
TelephonyProvider
CallLogProvider
sh
su
media
sdcard
ApplicationsProvider
