### PR TITLE
Add category checkbox to restriction prompt

### DIFF
--- a/res/layout/restrictionchild.xml
+++ b/res/layout/restrictionchild.xml
@@ -30,11 +30,21 @@
 
     <CheckedTextView
         android:id="@+id/ctvMethodName"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="?android:attr/listPreferredItemHeightSmall"
+        android:layout_weight="1"
         android:checkMark="?android:attr/listChoiceIndicatorMultiple"
         android:gravity="center_vertical"
         android:paddingLeft="6dip"
         android:textAppearance="?android:attr/textAppearanceSmall" />
+
+    <TextView
+        android:id="@+id/tvChosen"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:text="@string/msg_question"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:visibility="invisible" />
 
 </LinearLayout>

--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">تعليمي</string>
     <string name="menu_exclude">إستبعاد</string>
     <string name="menu_close">إغلاق</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">إيقاف</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">جديد</string>

--- a/res/values-bg/strings.xml
+++ b/res/values-bg/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">New</string>

--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">Nou</string>

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Příručka</string>
     <string name="menu_exclude">Vyloučit</string>
     <string name="menu_close">Zavřít</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Probíha přerušení</string>
     <string name="msg_aborted">Přerušeno</string>
     <string name="msg_new">Nové</string>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">Ny</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Ausschließen</string>
     <string name="menu_close">Schließen</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Abbrechen</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">Neu</string>

--- a/res/values-ee/strings.xml
+++ b/res/values-ee/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">New</string>

--- a/res/values-el/strings.xml
+++ b/res/values-el/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">New</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">Nuevo</string>

--- a/res/values-fa/strings.xml
+++ b/res/values-fa/strings.xml
@@ -44,6 +44,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">New</string>

--- a/res/values-fi/strings.xml
+++ b/res/values-fi/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">Uusi</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Didacticiel</string>
     <string name="menu_exclude">Exclure</string>
     <string name="menu_close">Fermer</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Arrêt en cours</string>
     <string name="msg_aborted">Arrêté</string>
     <string name="msg_new">Nouv. :</string>

--- a/res/values-ga/strings.xml
+++ b/res/values-ga/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">Nua</string>

--- a/res/values-he/strings.xml
+++ b/res/values-he/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">New</string>

--- a/res/values-hi/strings.xml
+++ b/res/values-hi/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">शिक्षा</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">नया</string>

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Útmutató</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">Új</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">Nuovo</string>

--- a/res/values-iw/strings.xml
+++ b/res/values-iw/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">New</string>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">新規</string>

--- a/res/values-lt/strings.xml
+++ b/res/values-lt/strings.xml
@@ -43,6 +43,7 @@
     <string name="menu_tutorial">Instrukcija</string>
     <string name="menu_exclude">Išskirti</string>
     <string name="menu_close">Uždaryti</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Nutraukti</string>
     <string name="msg_aborted">Atmesti</string>
     <string name="msg_new">Naujas</string>

--- a/res/values-nb-rNO/strings.xml
+++ b/res/values-nb-rNO/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Innføring</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">Nytt</string>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Zelfstudie</string>
     <string name="menu_exclude">Sluit uit</string>
     <string name="menu_close">Sluiten</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Afbreken</string>
     <string name="msg_aborted">Afgebroken</string>
     <string name="msg_new">Nieuw</string>

--- a/res/values-nn-rNO/strings.xml
+++ b/res/values-nn-rNO/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Innføring</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">Nytt</string>

--- a/res/values-no-rNO/strings.xml
+++ b/res/values-no-rNO/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Innføring</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">Nytt</string>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Samouczek</string>
     <string name="menu_exclude">Wyklucz</string>
     <string name="menu_close">Zamknij</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Przerywanie</string>
     <string name="msg_aborted">Przerwano</string>
     <string name="msg_new">Nowa aplikacja</string>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">New</string>

--- a/res/values-ro/strings.xml
+++ b/res/values-ro/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">New</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Обучение</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">Новое</string>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Príručka</string>
     <string name="menu_exclude">Vylúčiť</string>
     <string name="menu_close">Zavrieť</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Rušenie</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">Nové</string>

--- a/res/values-sl/strings.xml
+++ b/res/values-sl/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Navodila</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">Novo</string>

--- a/res/values-sr/strings.xml
+++ b/res/values-sr/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">New</string>

--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">Ny</string>

--- a/res/values-tl-rPH/strings.xml
+++ b/res/values-tl-rPH/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Sangguni</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">Bago</string>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">New</string>

--- a/res/values-ua/strings.xml
+++ b/res/values-ua/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Навчання</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">Нове</string>

--- a/res/values-vi/strings.xml
+++ b/res/values-vi/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">Hướng dẫn</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">Mới</string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">界面功能指引</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">新应用</string>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -42,6 +42,7 @@
     <string name="menu_tutorial">說明</string>
     <string name="menu_exclude">排除</string>
     <string name="menu_close">關閉</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">正在取消...</string>
     <string name="msg_aborted">已取消</string>
     <string name="msg_new">已安裝</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="menu_tutorial">Tutorial</string>
     <string name="menu_exclude">Exclude</string>
     <string name="menu_close">Close</string>
+    <string name="menu_category">Act on the entire category</string>
     <string name="msg_abort">Aborting</string>
     <string name="msg_aborted">Aborted</string>
     <string name="msg_new">New</string>

--- a/src/biz/bokhorst/xprivacy/ActivityApp.java
+++ b/src/biz/bokhorst/xprivacy/ActivityApp.java
@@ -1104,6 +1104,7 @@ public class ActivityApp extends Activity {
 			public ImageView imgUsed;
 			public ImageView imgGranted;
 			public CheckedTextView ctvMethodName;
+			private TextView tvChosen;
 
 			private ChildViewHolder(View theRow, int gPosition, int cPosition) {
 				row = theRow;
@@ -1112,6 +1113,7 @@ public class ActivityApp extends Activity {
 				imgUsed = (ImageView) row.findViewById(R.id.imgUsed);
 				imgGranted = (ImageView) row.findViewById(R.id.imgGranted);
 				ctvMethodName = (CheckedTextView) row.findViewById(R.id.ctvMethodName);
+				tvChosen = (TextView) row.findViewById(R.id.tvChosen);
 			}
 		}
 
@@ -1125,6 +1127,7 @@ public class ActivityApp extends Activity {
 			private boolean parentRestricted;
 			private boolean permission;
 			private boolean restricted;
+			private boolean asked;
 
 			public ChildHolderTask(int gPosition, int cPosition, ChildViewHolder theHolder, String theRestrictionName) {
 				groupPosition = gPosition;
@@ -1141,7 +1144,14 @@ public class ActivityApp extends Activity {
 					lastUsage = PrivacyManager.getUsed(mAppInfo.getUid(), restrictionName, md.getName());
 					parentRestricted = PrivacyManager.getRestrictionEx(mAppInfo.getUid(), restrictionName, null).restricted;
 					permission = PrivacyManager.hasPermission(ActivityApp.this, mAppInfo, md);
-					restricted = PrivacyManager.getRestrictionEx(mAppInfo.getUid(), restrictionName, md.getName()).restricted;
+					ParcelableRestriction query = PrivacyManager.getRestrictionEx(mAppInfo.getUid(), restrictionName, md.getName());
+					restricted = query.restricted;
+
+					if (PrivacyManager.getSettingBool(null, -mAppInfo.getUid(), PrivacyManager.cSettingOnDemand, false,
+							false))
+						asked = query.asked;
+					else
+						asked = true;
 
 					return holder;
 				}
@@ -1165,6 +1175,8 @@ public class ActivityApp extends Activity {
 					holder.ctvMethodName.setTypeface(null, lastUsage == 0 ? Typeface.NORMAL : Typeface.BOLD_ITALIC);
 					holder.imgGranted.setVisibility(permission ? View.VISIBLE : View.INVISIBLE);
 					holder.ctvMethodName.setChecked(restricted);
+
+					holder.tvChosen.setVisibility(asked ? View.INVISIBLE : View.VISIBLE);
 
 					// Listen for restriction changes
 					holder.ctvMethodName.setOnClickListener(new View.OnClickListener() {

--- a/tools/addstring.sh
+++ b/tools/addstring.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-grep -RIl "\<string name=\"menu_clear_usage" res | xargs sed -i -e '/menu_clear_usage/a \
-\ \ \ \ <string name="menu_clear_db">Clear all data</string>'
+grep -RIl "\<string name=\"menu_close" res | xargs sed -i -e '/menu_close/a \
+\ \ \ \ <string name="menu_category">Act on the entire category</string>'
 
 #grep -RIl "\<string name=\"menu_clear_ondemand" res | xargs sed -i -e '/menu_clear_ondemand/d'
 #grep -RIl "\<string name=\"menu_app_store" res | xargs sed -i -e 's/%$3s/%3$s/g'


### PR DESCRIPTION
I have tested this every which way and it works perfectly. If you allow/deny a single function, the rest of the functions in the category are still considered undetermined, except for the dangerous ones if you don't have Restrict dangerous ticked.

There is a strange bug that has taken me ages to narrow down concerning the displaying of functions with no usage data, but which don't require an app restart.
