### PR TITLE
setSettingInternal clears restriction cache when storing a whitelist

### DIFF
--- a/src/biz/bokhorst/xprivacy/PrivacyService.java
+++ b/src/biz/bokhorst/xprivacy/PrivacyService.java
@@ -953,6 +953,11 @@ public class PrivacyService {
 							mSettingCache.put(key, key);
 					}
 				}
+
+				if (setting.name.startsWith("Whitelist"))
+					synchronized (mRestrictionCache) {
+						mRestrictionCache.clear();
+					}
 			} catch (Throwable ex) {
 				Util.bug(null, ex);
 				throw new RemoteException(ex.toString());


### PR DESCRIPTION
You might find this solution a little heavy-handed, but I can't think of anything better for the moment.
