### PR TITLE
Slovenian translate updated(strings migrated to positional format)

### DIFF
--- a/res/values-sl/strings.xml
+++ b/res/values-sl/strings.xml
@@ -1,12 +1,12 @@
 <resources>
 
-    <string name="app_notxposed" formatted="false">Xposed framework različice %d+ ni nameščen</string>
+    <string name="app_notxposed">Xposed framework različice %1$d+ ni nameščen</string>
     <string name="app_notenabled">XPrivacy ni omogočen v Xposed installer</string>
     <string name="app_wrongandroid">Samo za Android različice 4.0.3+</string>
-    <string name="app_incompatible" formatted="false">XPrivacy is incompatible with %s</string>
-    <string name="app_version" formatted="false">XPrivacy različica: %s (%d)</string>
+    <string name="app_incompatible">XPrivacy is incompatible with %1$s</string>
+    <string name="app_version">XPrivacy različica: %1$s (%2$d)</string>
     <string name="app_description">Odlični upravljalec pravic</string>
-    <string name="app_xversion" formatted="false">Xposed framework različica: %d</string>
+    <string name="app_xversion">Xposed framework različica: %1$d</string>
     <string name="app_copyright">Copyright \u00A9 2013–2014 by M. Bokhorst (M66B)</string>
     <string name="app_licensed">Lincecirano, hvala za Vašo podporo!</string>
     <string name="menu_usage">Uporaba</string>
@@ -52,11 +52,11 @@
     <string name="msg_loading">Nalagam</string>
     <string name="msg_applying">Uveljavljam</string>
     <string name="msg_applied">Predloga uveljavljena</string>
-    <string name="msg_saved_to" formatted="false">Shranjeno v %s</string>
+    <string name="msg_saved_to">Shranjeno v %1$s</string>
     <string name="msg_no_restrictions">Ni bilo najdenih omejitev</string>
     <string name="msg_sure">Ste prepričani?</string>
     <string name="msg_select">Prosimo, izberite nekaj programov</string>
-    <string name="msg_limit">Prosimo, izberite manj kot %d programov</string>
+    <string name="msg_limit">Prosimo, izberite manj kot %1$d programov</string>
     <string name="msg_done">Dokončano</string>
     <string name="msg_reboot">Zahtevan ponovni zagon</string>
     <string name="msg_random_now">Naključni podatki</string>
@@ -67,9 +67,9 @@
     <string name="msg_email">Prosimo, vnesite svoj e-mail naslov:</string>
     <string name="msg_registered">Za aktiviranje Vaše naprave, preverite e-pošto</string>
     <string name="msg_service">Posodobi zagnane storitve</string>
-    <string name="msg_migrating" formatted="false">Selim %s</string>
-    <string name="msg_randomizing" formatted="false">Ustvarjam naključne podatke %s</string>
-    <string name="msg_upgrading" formatted="false">Nadgrajujem %s</string>
+    <string name="msg_migrating">Selim %1$s</string>
+    <string name="msg_randomizing">Ustvarjam naključne podatke %1$s</string>
+    <string name="msg_upgrading">Nadgrajujem %1$s</string>
     <string name="msg_support_info">Napaka pri notranjem preverjanju, želite poslati podatke podpori?</string>
     <string name="msg_restrictedby">Omejeno z XPrivacy</string>
     <string name="msg_first"><b>Za razvoj in preizkušanje programa XPrivacy je bilo vloženo veliko truda, vendar pa
@@ -124,7 +124,7 @@
     <string name="title_parameters">Parametri:</string>
     <string name="title_applycat">Uveljavi za celotno kategorijo</string>
     <string name="title_once">Enkrat na %1$s sekund</string>
-    <string name="title_whitelist">Dodaj \'%s\' na belo listo</string>
+    <string name="title_whitelist">Dodaj \'%1$s\' na belo listo</string>
     <string name="title_allow">Dovoli</string>
     <string name="title_deny">Zavrni</string>
     <string name="title_pleasesubmit">Prosimo, pošljite Vaše omejitve za pomoč drugim</string>


### PR DESCRIPTION
As I understand I had to remove the 'formatted="flase" ' from strings and replace the %s and %d to %n$s and %n$d (where n is number of the parameter) if I understand this correctly.
