### PR TITLE
Readme links to screenshots changed for better presentability (2 columns)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ OR
 
 **Using XPrivacy is entirely at your own risk**
 
-<img src="https://raw.github.com/M66B/XPrivacy/master/screenshots/applications.png" width="350" hspace="5"/>
-<img src="https://raw.github.com/M66B/XPrivacy/master/screenshots/categories.png" width="350" hspace="5"/>
-<img src="https://raw.github.com/M66B/XPrivacy/master/screenshots/application.png" width="350" hspace="5"/>
-<img src="https://raw.github.com/M66B/XPrivacy/master/screenshots/expert.png" width="350" hspace="5"/>
-<img src="https://raw.github.com/M66B/XPrivacy/master/screenshots/help.png" width="350" hspace="5"/>
-<img src="https://raw.github.com/M66B/XPrivacy/master/screenshots/settings.png" width="350" hspace="5"/>
-<img src="https://raw.github.com/M66B/XPrivacy/master/screenshots/usagedata.png" width="350" hspace="5"/>
-<img src="https://raw.github.com/M66B/XPrivacy/master/screenshots/menu.png" width="350" hspace="5"/>
+<img src="screenshots/applications.png" width="350" hspace="5"/>
+<img src="screenshots/categories.png" width="350" hspace="5"/>
+<img src="screenshots/application.png" width="350" hspace="5"/>
+<img src="screenshots/expert.png" width="350" hspace="5"/>
+<img src="screenshots/help.png" width="350" hspace="5"/>
+<img src="screenshots/settings.png" width="350" hspace="5"/>
+<img src="screenshots/usagedata.png" width="350" hspace="5"/>
+<img src="screenshots/menu.png" width="350" hspace="5"/>
 
 Features
 --------


### PR DESCRIPTION
Embedded readme links to screenshots now use html <img> tags instead of markdown format in oder to allow for displaying 2 columns in all cases. Additionally, they have been changed from absolute to relative format. They now refer to the images in the working repository (previously m66B/master was always referenced).
