### PR TITLE
Show function help popup in a dialog

### DIFF
--- a/res/layout/popup.xml
+++ b/res/layout/popup.xml
@@ -11,7 +11,6 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/background_tutorial"
         android:orientation="vertical" >
 
         <TextView
@@ -25,14 +24,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="12dip" />
-
-        <Button
-            android:id="@+id/btnOk"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginTop="12dip"
-            android:text="@android:string/ok" />
     </LinearLayout>
 
 </ScrollView>

--- a/src/biz/bokhorst/xprivacy/ActivityApp.java
+++ b/src/biz/bokhorst/xprivacy/ActivityApp.java
@@ -47,17 +47,15 @@ import android.text.format.DateUtils;
 import android.text.method.LinkMovementMethod;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
-import android.view.View.OnClickListener;
-import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.view.Window;
-import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
@@ -69,7 +67,6 @@ import android.widget.ExpandableListView;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ListView;
-import android.widget.PopupWindow;
 import android.widget.ProgressBar;
 import android.widget.ScrollView;
 import android.widget.Spinner;
@@ -1778,12 +1775,19 @@ public class ActivityApp extends ActivityBase {
 
 	@SuppressLint("InflateParams")
 	public static void showHelp(ActivityBase context, View parent, Hook hook) {
-		LayoutInflater inflator = LayoutInflater.from(context);
-		View layout = inflator.inflate(R.layout.popup, null);
+		// Build dialog
+		Dialog dlgHelp = new Dialog(context);
+		dlgHelp.requestWindowFeature(Window.FEATURE_LEFT_ICON);
+		dlgHelp.setTitle(R.string.app_name);
+		dlgHelp.setContentView(R.layout.popup);
+		dlgHelp.setFeatureDrawableResource(Window.FEATURE_LEFT_ICON, context.getThemed(R.attr.icon_launcher));
+		dlgHelp.setCancelable(true);
 
-		TextView tvTitle = (TextView) layout.findViewById(R.id.tvTitle);
+		// Set text title
+		TextView tvTitle = (TextView) dlgHelp.findViewById(R.id.tvTitle);
 		tvTitle.setText(hook.getName());
 
+		// Set text content
 		String text = hook.getAnnotation();
 		String[] permissions = hook.getPermissions();
 		if (permissions != null && permissions.length > 0) {
@@ -1794,23 +1798,10 @@ public class ActivityApp extends ActivityBase {
 				text += TextUtils.join("<br />", permissions);
 		}
 
-		TextView tvInfo = (TextView) layout.findViewById(R.id.tvInfo);
+		TextView tvInfo = (TextView) dlgHelp.findViewById(R.id.tvInfo);
 		tvInfo.setText(Html.fromHtml(text));
 		tvInfo.setMovementMethod(LinkMovementMethod.getInstance());
 
-		final PopupWindow popup = new PopupWindow(layout);
-		popup.setHeight(WindowManager.LayoutParams.WRAP_CONTENT);
-		popup.setWidth(90 * parent.getWidth() / 100);
-
-		Button btnOk = (Button) layout.findViewById(R.id.btnOk);
-		btnOk.setOnClickListener(new View.OnClickListener() {
-			@Override
-			public void onClick(View view) {
-				if (popup.isShowing())
-					popup.dismiss();
-			}
-		});
-
-		popup.showAtLocation(parent, Gravity.CENTER, 0, 0);
+		dlgHelp.show();
 	}
 }


### PR DESCRIPTION
Current function help shows a popup that overlays the function list, it wont disappear unless you click on the OK button (thus you can stack multiple popups if you click on various help links).

This commit changes the function help popup to a dialog, so if you touch outside the dialog it will disappear.

![2014-08-30 16 28 45](https://cloud.githubusercontent.com/assets/3890441/4099255/062bf528-3054-11e4-8269-fb155c7f7c4d.png)
