### PR TITLE
Fix Android 5.x Boot Loop issues

### DIFF
--- a/src/biz/bokhorst/xprivacy/XPrivacy.java
+++ b/src/biz/bokhorst/xprivacy/XPrivacy.java
@@ -121,6 +121,8 @@ public class XPrivacy implements IXposedHookLoadPackage, IXposedHookZygoteInit {
 
 			hookAll(null);
 		}
+		
+		hookAll();
 	}
 
 	private static void handleLoadPackage(String packageName, String processName, final ClassLoader classLoader,
@@ -223,6 +225,11 @@ public class XPrivacy implements IXposedHookLoadPackage, IXposedHookZygoteInit {
 
 		// Providers
 		hookAll(XContentResolver.getPackageInstances(packageName, classLoader), classLoader, secret, false);
+	}
+	
+	private static void hookAll() {
+		// Intent receive
+		hookAll(XActivityThread.getInstances(), null, mSecret, false);
 	}
 
 	private static void hookAll(final ClassLoader classLoader) {
@@ -354,9 +361,6 @@ public class XPrivacy implements IXposedHookLoadPackage, IXposedHookZygoteInit {
 
 		// Wi-Fi service
 		hookAll(XWifiManager.getInstances(null, true), classLoader, mSecret, false);
-
-		// Intent receive
-		hookAll(XActivityThread.getInstances(), classLoader, mSecret, false);
 
 		// Intent send
 		hookAll(XActivity.getInstances(), classLoader, mSecret, false);


### PR DESCRIPTION
Whether or not this is an Xposed issue I am not sure. But trying to add a hook to ActivityThread after it has been loaded will cause a boot loop issue. It seams that doing so destroys the entire dalvik cache for some reason. Moving the hook to ZygoteInit, like in pre-lollipop, fixes the boot loop issue.