### PR TITLE
Add full Lollipop compatibillity

### DIFF
--- a/src/biz/bokhorst/xprivacy/PrivacyService.java
+++ b/src/biz/bokhorst/xprivacy/PrivacyService.java
@@ -167,11 +167,9 @@ public class PrivacyService extends IPrivacyService.Stub {
 			XActivityManagerService.setSemaphore(mOndemandSemaphore);
 
 			// Get context
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-				Field fContext = am.getClass().getDeclaredField("mContext");
-				fContext.setAccessible(true);
-				mContext = (Context) fContext.get(am);
-			}
+			Field fContext = am.getClass().getDeclaredField("mContext");
+			fContext.setAccessible(true);
+			mContext = (Context) fContext.get(am);
 
 			// Start a worker thread
 			mWorker = new Thread(new Runnable() {
@@ -2293,24 +2291,7 @@ public class PrivacyService extends IPrivacyService.Stub {
 	}
 
 	private Context getContext() {
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-			return mContext;
-		else {
-			// public static ActivityManagerService self()
-			// frameworks/base/services/java/com/android/server/am/ActivityManagerService.java
-			try {
-				Class<?> cam = Class.forName("com.android.server.am.ActivityManagerService");
-				Object am = cam.getMethod("self").invoke(null);
-				if (am == null)
-					return null;
-				Field mContext = cam.getDeclaredField("mContext");
-				mContext.setAccessible(true);
-				return (Context) mContext.get(am);
-			} catch (Throwable ex) {
-				Util.bug(null, ex);
-				return null;
-			}
-		}
+		return mContext;
 	}
 
 	private int getIsolatedUid(int uid) {

--- a/src/biz/bokhorst/xprivacy/XAccountManager.java
+++ b/src/biz/bokhorst/xprivacy/XAccountManager.java
@@ -102,19 +102,19 @@ public class XAccountManager extends XHook {
 				listHook.add(new XAccountManager(Methods.Srv_getAccountsByFeatures, PrivacyManager.cAccounts));
 				listHook.add(new XAccountManager(Methods.Srv_getAccountsForPackage, PrivacyManager.cAccounts));
 				listHook.add(new XAccountManager(Methods.Srv_getSharedAccountsAsUser, PrivacyManager.cAccounts));
+			} else {
+				listHook.add(new XAccountManager(Methods.addOnAccountsUpdatedListener, PrivacyManager.cAccounts, className));
+				listHook.add(new XAccountManager(Methods.blockingGetAuthToken, PrivacyManager.cAccounts, className));
+				listHook.add(new XAccountManager(Methods.getAccounts, PrivacyManager.cAccounts, className));
+				listHook.add(new XAccountManager(Methods.getAccountsByType, PrivacyManager.cAccounts, className));
+				listHook.add(new XAccountManager(Methods.getAccountsByTypeForPackage, PrivacyManager.cAccounts, className));
+				listHook.add(new XAccountManager(Methods.getAccountsByTypeAndFeatures, PrivacyManager.cAccounts, className));
+				listHook.add(new XAccountManager(Methods.getAuthenticatorTypes, PrivacyManager.cAccounts, className));
+				listHook.add(new XAccountManager(Methods.getAuthToken, PrivacyManager.cAccounts, className));
+				listHook.add(new XAccountManager(Methods.getAuthTokenByFeatures, PrivacyManager.cAccounts, className));
+				listHook.add(new XAccountManager(Methods.hasFeatures, PrivacyManager.cAccounts, className));
+				listHook.add(new XAccountManager(Methods.removeOnAccountsUpdatedListener, null, className));
 			}
-
-			listHook.add(new XAccountManager(Methods.addOnAccountsUpdatedListener, PrivacyManager.cAccounts, className));
-			listHook.add(new XAccountManager(Methods.blockingGetAuthToken, PrivacyManager.cAccounts, className));
-			listHook.add(new XAccountManager(Methods.getAccounts, PrivacyManager.cAccounts, className));
-			listHook.add(new XAccountManager(Methods.getAccountsByType, PrivacyManager.cAccounts, className));
-			listHook.add(new XAccountManager(Methods.getAccountsByTypeForPackage, PrivacyManager.cAccounts, className));
-			listHook.add(new XAccountManager(Methods.getAccountsByTypeAndFeatures, PrivacyManager.cAccounts, className));
-			listHook.add(new XAccountManager(Methods.getAuthenticatorTypes, PrivacyManager.cAccounts, className));
-			listHook.add(new XAccountManager(Methods.getAuthToken, PrivacyManager.cAccounts, className));
-			listHook.add(new XAccountManager(Methods.getAuthTokenByFeatures, PrivacyManager.cAccounts, className));
-			listHook.add(new XAccountManager(Methods.hasFeatures, PrivacyManager.cAccounts, className));
-			listHook.add(new XAccountManager(Methods.removeOnAccountsUpdatedListener, null, className));
 		}
 		return listHook;
 	}

--- a/src/biz/bokhorst/xprivacy/XActivityManager.java
+++ b/src/biz/bokhorst/xprivacy/XActivityManager.java
@@ -80,7 +80,7 @@ public class XActivityManager extends XHook {
 							listHook.add(new XActivityManager(act, null, null));
 						else
 							listHook.add(new XActivityManager(act, PrivacyManager.cSystem, null));
-				} else
+				} else if (!server)
 					listHook.add(new XActivityManager(act, PrivacyManager.cSystem, className));
 		}
 		return listHook;

--- a/src/biz/bokhorst/xprivacy/XAppWidgetManager.java
+++ b/src/biz/bokhorst/xprivacy/XAppWidgetManager.java
@@ -42,12 +42,15 @@ public class XAppWidgetManager extends XHook {
 		getInstalledProviders, getInstalledProvidersForProfile, Srv_getInstalledProviders, Srv_getInstalledProvidersForProfile
 	};
 
-	public static List<XHook> getInstances() {
+	public static List<XHook> getInstances(boolean services) {
 		List<XHook> listHook = new ArrayList<XHook>();
-		listHook.add(new XAppWidgetManager(Methods.getInstalledProviders, PrivacyManager.cSystem));
-		listHook.add(new XAppWidgetManager(Methods.getInstalledProvidersForProfile, PrivacyManager.cSystem));
-		listHook.add(new XAppWidgetManager(Methods.Srv_getInstalledProviders, PrivacyManager.cSystem));
-		listHook.add(new XAppWidgetManager(Methods.Srv_getInstalledProvidersForProfile, PrivacyManager.cSystem));
+		if (!services) {
+			listHook.add(new XAppWidgetManager(Methods.getInstalledProviders, PrivacyManager.cSystem));
+			listHook.add(new XAppWidgetManager(Methods.getInstalledProvidersForProfile, PrivacyManager.cSystem));
+		} else {
+			listHook.add(new XAppWidgetManager(Methods.Srv_getInstalledProviders, PrivacyManager.cSystem));
+			listHook.add(new XAppWidgetManager(Methods.Srv_getInstalledProvidersForProfile, PrivacyManager.cSystem));
+		}
 		return listHook;
 	}
 

--- a/src/biz/bokhorst/xprivacy/XBluetoothAdapter.java
+++ b/src/biz/bokhorst/xprivacy/XBluetoothAdapter.java
@@ -41,12 +41,15 @@ public class XBluetoothAdapter extends XHook {
 		getAddress, getBondedDevices, Srv_getAddress, Srv_getName
 	};
 
-	public static List<XHook> getInstances() {
+	public static List<XHook> getInstances(boolean services) {
 		List<XHook> listHook = new ArrayList<XHook>();
-		listHook.add(new XBluetoothAdapter(Methods.getAddress, PrivacyManager.cNetwork));
-		listHook.add(new XBluetoothAdapter(Methods.getBondedDevices, PrivacyManager.cNetwork));
-		listHook.add(new XBluetoothAdapter(Methods.Srv_getAddress, PrivacyManager.cNetwork));
-		listHook.add(new XBluetoothAdapter(Methods.Srv_getName, PrivacyManager.cNetwork));
+		if (!services) {
+			listHook.add(new XBluetoothAdapter(Methods.getAddress, PrivacyManager.cNetwork));
+			listHook.add(new XBluetoothAdapter(Methods.getBondedDevices, PrivacyManager.cNetwork));
+		} else {
+			listHook.add(new XBluetoothAdapter(Methods.Srv_getAddress, PrivacyManager.cNetwork));
+			listHook.add(new XBluetoothAdapter(Methods.Srv_getName, PrivacyManager.cNetwork));
+		}
 		return listHook;
 	}
 

--- a/src/biz/bokhorst/xprivacy/XClipboardManager.java
+++ b/src/biz/bokhorst/xprivacy/XClipboardManager.java
@@ -75,7 +75,7 @@ public class XClipboardManager extends XHook {
 							listHook.add(new XClipboardManager(clip, null));
 						else
 							listHook.add(new XClipboardManager(clip, PrivacyManager.cClipboard));
-				} else {
+				} else if (!server) {
 					if (clip == Methods.removePrimaryClipChangedListener)
 						listHook.add(new XClipboardManager(clip, null, className));
 					else

--- a/src/biz/bokhorst/xprivacy/XContentResolver.java
+++ b/src/biz/bokhorst/xprivacy/XContentResolver.java
@@ -167,11 +167,22 @@ public class XContentResolver extends XHook {
 			return listHook;
 		}
 	}
+	
+	private static List<XHook> getInstances(String className) {
+		List<XHook> listHook = new ArrayList<XHook>();
+		
+		if ("com.android.providers.settings.SettingsProvider".equals(className))
+			listHook.add(new XContentResolver(Methods.Srv_call, null, className));
+		else
+			listHook.add(new XContentResolver(Methods.Srv_query, null, className));
+		
+		return listHook;
+	}
 
-	public static List<XHook> getInstances(String className) {
+	public static List<XHook> getInstances(boolean services) {
 		List<XHook> listHook = new ArrayList<XHook>();
 
-		if (className == null) {
+		if (!services) {
 			listHook.add(new XContentResolver(Methods.getCurrentSync, PrivacyManager.cAccounts, false));
 			listHook.add(new XContentResolver(Methods.getCurrentSyncs, PrivacyManager.cAccounts, false));
 			listHook.add(new XContentResolver(Methods.getSyncAdapterTypes, PrivacyManager.cAccounts, false));
@@ -188,15 +199,11 @@ public class XContentResolver extends XHook {
 
 			listHook.add(new XContentResolver(Methods.query, null, false));
 			listHook.add(new XContentResolver(Methods.query, null, true));
+		} else {
 			listHook.add(new XContentResolver(Methods.Srv_query, null, "com.android.internal.telephony.IccProvider"));
 
 			listHook.add(new XContentResolver(Methods.Srv_getCurrentSyncs, PrivacyManager.cAccounts, null));
 			listHook.add(new XContentResolver(Methods.Srv_getCurrentSyncsAsUser, PrivacyManager.cAccounts, null));
-		} else {
-			if ("com.android.providers.settings.SettingsProvider".equals(className))
-				listHook.add(new XContentResolver(Methods.Srv_call, null, className));
-			else
-				listHook.add(new XContentResolver(Methods.Srv_query, null, className));
 		}
 
 		return listHook;

--- a/src/biz/bokhorst/xprivacy/XPackageManager.java
+++ b/src/biz/bokhorst/xprivacy/XPackageManager.java
@@ -122,23 +122,23 @@ public class XPackageManager extends XHook {
 				listHook.add(new XPackageManager(Methods.Srv_queryIntentContentProviders, PrivacyManager.cSystem));
 				listHook.add(new XPackageManager(Methods.Srv_queryIntentReceivers, PrivacyManager.cSystem));
 				listHook.add(new XPackageManager(Methods.Srv_queryIntentServices, PrivacyManager.cSystem));
+			} else {
+				listHook.add(new XPackageManager(Methods.getInstalledApplications, PrivacyManager.cSystem, className));
+				listHook.add(new XPackageManager(Methods.getInstalledPackages, PrivacyManager.cSystem, className));
+				listHook.add(new XPackageManager(Methods.getPackagesForUid, PrivacyManager.cSystem, className));
+				listHook.add(new XPackageManager(Methods.getPackagesHoldingPermissions, PrivacyManager.cSystem, className));
+				listHook.add(new XPackageManager(Methods.getPreferredActivities, PrivacyManager.cSystem, className));
+				listHook.add(new XPackageManager(Methods.getPreferredPackages, PrivacyManager.cSystem, className));
+				listHook.add(new XPackageManager(Methods.queryBroadcastReceivers, PrivacyManager.cSystem, className));
+				listHook.add(new XPackageManager(Methods.queryContentProviders, PrivacyManager.cSystem, className));
+				listHook.add(new XPackageManager(Methods.queryIntentActivities, PrivacyManager.cSystem, className));
+				listHook.add(new XPackageManager(Methods.queryIntentActivityOptions, PrivacyManager.cSystem, className));
+				listHook.add(new XPackageManager(Methods.queryIntentContentProviders, PrivacyManager.cSystem, className));
+				listHook.add(new XPackageManager(Methods.queryIntentServices, PrivacyManager.cSystem, className));
+	
+				listHook.add(new XPackageManager(Methods.checkPermission, PrivacyManager.cSystem));
+				listHook.add(new XPackageManager(Methods.checkUidPermission, PrivacyManager.cSystem));
 			}
-
-			listHook.add(new XPackageManager(Methods.getInstalledApplications, PrivacyManager.cSystem, className));
-			listHook.add(new XPackageManager(Methods.getInstalledPackages, PrivacyManager.cSystem, className));
-			listHook.add(new XPackageManager(Methods.getPackagesForUid, PrivacyManager.cSystem, className));
-			listHook.add(new XPackageManager(Methods.getPackagesHoldingPermissions, PrivacyManager.cSystem, className));
-			listHook.add(new XPackageManager(Methods.getPreferredActivities, PrivacyManager.cSystem, className));
-			listHook.add(new XPackageManager(Methods.getPreferredPackages, PrivacyManager.cSystem, className));
-			listHook.add(new XPackageManager(Methods.queryBroadcastReceivers, PrivacyManager.cSystem, className));
-			listHook.add(new XPackageManager(Methods.queryContentProviders, PrivacyManager.cSystem, className));
-			listHook.add(new XPackageManager(Methods.queryIntentActivities, PrivacyManager.cSystem, className));
-			listHook.add(new XPackageManager(Methods.queryIntentActivityOptions, PrivacyManager.cSystem, className));
-			listHook.add(new XPackageManager(Methods.queryIntentContentProviders, PrivacyManager.cSystem, className));
-			listHook.add(new XPackageManager(Methods.queryIntentServices, PrivacyManager.cSystem, className));
-
-			listHook.add(new XPackageManager(Methods.checkPermission, PrivacyManager.cSystem));
-			listHook.add(new XPackageManager(Methods.checkUidPermission, PrivacyManager.cSystem));
 		}
 		return listHook;
 	}

--- a/src/biz/bokhorst/xprivacy/XParam.java
+++ b/src/biz/bokhorst/xprivacy/XParam.java
@@ -29,6 +29,11 @@ public class XParam {
 		xparam.args = param.args;
 		xparam.mResult = param.getResult();
 		xparam.mThrowable = param.getThrowable();
+		
+		if (xparam.args == null) {
+			xparam.args = new Object[]{};
+		}
+		
 		return xparam;
 	}
 

--- a/src/biz/bokhorst/xprivacy/XPrivacy.java
+++ b/src/biz/bokhorst/xprivacy/XPrivacy.java
@@ -121,6 +121,8 @@ public class XPrivacy implements IXposedHookLoadPackage, IXposedHookZygoteInit {
 
 			hookAll(null);
 		}
+		
+		hookAll();
 	}
 
 	private static void handleLoadPackage(String packageName, String processName, final ClassLoader classLoader,
@@ -223,6 +225,11 @@ public class XPrivacy implements IXposedHookLoadPackage, IXposedHookZygoteInit {
 
 		// Providers
 		hookAll(XContentResolver.getPackageInstances(packageName, classLoader), classLoader, secret, false);
+	}
+	
+	private static void hookAll() {
+		// Intent receive
+		hookAll(XActivityThread.getInstances(), null, mSecret, false);
 	}
 
 	private static void hookAll(final ClassLoader classLoader) {
@@ -354,9 +361,6 @@ public class XPrivacy implements IXposedHookLoadPackage, IXposedHookZygoteInit {
 
 		// Wi-Fi service
 		hookAll(XWifiManager.getInstances(null, true), classLoader, mSecret, false);
-
-		// Intent receive
-		hookAll(XActivityThread.getInstances(), classLoader, mSecret, false);
 
 		// Intent send
 		hookAll(XActivity.getInstances(), classLoader, mSecret, false);

--- a/src/biz/bokhorst/xprivacy/XPrivacy.java
+++ b/src/biz/bokhorst/xprivacy/XPrivacy.java
@@ -17,7 +17,6 @@ import android.content.Context;
 import android.os.Build;
 import android.os.Process;
 import android.util.Log;
-
 import de.robv.android.xposed.IXposedHookZygoteInit;
 import de.robv.android.xposed.IXposedHookLoadPackage;
 import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam;
@@ -29,64 +28,107 @@ public class XPrivacy implements IXposedHookLoadPackage, IXposedHookZygoteInit {
 	private static String mSecret = null;
 	private static List<String> mListHookError = new ArrayList<String>();
 	private static List<CRestriction> mListDisabled = new ArrayList<CRestriction>();
-
-	// http://developer.android.com/reference/android/Manifest.permission.html
-
-	static {
-		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP && mListDisabled.size() == 0) {
-			File disabled = new File("/data/system/xprivacy/disabled");
-			if (disabled.exists() && disabled.canRead())
-				try {
-					Log.w("XPrivacy", "Reading " + disabled.getAbsolutePath());
-					FileInputStream fis = new FileInputStream(disabled);
-					InputStreamReader ir = new InputStreamReader(fis);
-					BufferedReader br = new BufferedReader(ir);
-					String line;
-					while ((line = br.readLine()) != null)
-						if (line.length() > 0 && !line.startsWith("#")) {
-							String[] name = line.split("/");
-							if (name.length > 0) {
-								String methodName = (name.length > 1 ? name[1] : null);
-								CRestriction restriction = new CRestriction(0, name[0], methodName, null);
-								Log.w("XPrivacy", "Disabling " + restriction);
-								mListDisabled.add(restriction);
-							}
-						}
-					br.close();
-					ir.close();
-					fis.close();
-				} catch (Throwable ex) {
-					Log.w("XPrivacy", ex.toString());
-				}
-		}
-	}
-
-	// Xposed
+	private static boolean mHasErr = false;
+	
 	public void initZygote(StartupParam startupParam) throws Throwable {
 		// Check for LBE security master
 		if (Util.hasLBE()) {
 			Util.log(null, Log.ERROR, "LBE installed");
 			return;
 		}
+		
+		/*
+		 * ActivityManagerService is the beginning of the main "android" process. 
+		 * This is where the core java system is started, where the system context is created and so on. 
+		 * In pre-lollipop we can access this class directly, but in lollipop we have to visit ActivityThread first, 
+		 * since this class is now responsible for creating a class loader that can be used to access ActivityManagerService. 
+		 * It is no longer possible to do so via the normal boot class loader. Doing it like this will create a consistency between older and newer 
+		 * Android versions.
+		 * 
+		 * Note that there is no need to handle arguments in this case. And we don't need them so in case they change over time, we will simply use 
+		 * the hookAll feature. 
+		 */
+		try {
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+				XposedBridge.hookAllMethods(Class.forName("android.app.ActivityThread"), "systemMain", new XC_MethodHook() {
+					@Override
+					protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+						final ClassLoader loader = Thread.currentThread().getContextClassLoader();
+						
+						try {
+							XposedBridge.hookAllConstructors(Class.forName("com.android.server.am.ActivityManagerService", false, loader), new XC_MethodHook() {
+								@Override
+								protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+									bootstrapSystem(param.thisObject, loader);
+								}
+							});
+							
+						} catch (Throwable ex) {
+							Util.bug(null, ex); mHasErr = true;
+						}
+					}
+				});
+				
+			} else {
+				XposedBridge.hookAllMethods(Class.forName("com.android.server.am.ActivityManagerService"), "startRunning", new XC_MethodHook() {
+					@Override
+					protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+						bootstrapSystem(param.thisObject, null);
+					}
+				});
+			}
+			
+			bootstrapZygote();
 
-		init(startupParam.modulePath);
+		} catch (Throwable ex) {
+			Util.bug(null, ex); mHasErr = true;
+		}
 	}
-
+	
 	public void handleLoadPackage(final LoadPackageParam lpparam) throws Throwable {
 		// Check for LBE security master
-		if (Util.hasLBE())
+		int uid = Process.myUid();
+		
+		if (Util.hasLBE() || mHasErr || uid <= Process.SYSTEM_UID)
 			return;
 
-		handleLoadPackage(lpparam.packageName, lpparam.processName, lpparam.classLoader, lpparam.isFirstApplication,
-				mSecret);
+		bootstrapPackage(lpparam.packageName, lpparam.classLoader);
 	}
+	
 
-	// Common
-	private static void init(String path) {
-		Util.log(null, Log.WARN, "Init path=" + path);
-
+	private void bootstrapZygote() throws Throwable {
 		// Generate secret
 		mSecret = Long.toHexString(new Random().nextLong());
+		
+		/*
+		 * Zygote can access this file (Even with SELinux enabled) as it is running as the outer root. 
+		 * Since Zygote is the process that starts any other process, any sub-process will 
+		 * inherit the changes made to this class. Including values stored from /data/system/xprivacy/disabled.
+		 */
+		File disabled = new File("/data/system/xprivacy/disabled");
+		if (disabled.exists() && disabled.canRead())
+			try {
+				Log.w("XPrivacy", "Reading " + disabled.getAbsolutePath());
+				FileInputStream fis = new FileInputStream(disabled);
+				InputStreamReader ir = new InputStreamReader(fis);
+				BufferedReader br = new BufferedReader(ir);
+				String line;
+				while ((line = br.readLine()) != null)
+					if (line.length() > 0 && !line.startsWith("#")) {
+						String[] name = line.split("/");
+						if (name.length > 0) {
+							String methodName = (name.length > 1 ? name[1] : null);
+							CRestriction restriction = new CRestriction(0, name[0], methodName, null);
+							Log.w("XPrivacy", "Disabling " + restriction);
+							mListDisabled.add(restriction);
+						}
+					}
+				br.close();
+				ir.close();
+				fis.close();
+			} catch (Throwable ex) {
+				Log.w("XPrivacy", ex.toString());
+			}
 
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT)
 			try {
@@ -102,59 +144,205 @@ public class XPrivacy implements IXposedHookLoadPackage, IXposedHookZygoteInit {
 			} catch (Throwable ex) {
 				Util.bug(null, ex);
 			}
-
-		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-			// System server
-			try {
-				// frameworks/base/services/java/com/android/server/SystemServer.java
-				Class<?> cSystemServer = Class.forName("com.android.server.SystemServer");
-				Method mMain = cSystemServer.getDeclaredMethod("main", String[].class);
-				XposedBridge.hookMethod(mMain, new XC_MethodHook() {
-					@Override
-					protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
-						PrivacyService.register(mListHookError, null, mSecret, null);
-					}
-				});
-			} catch (Throwable ex) {
-				Util.bug(null, ex);
-			}
-
-			hookAll(null);
-		}
 		
-		hookAll();
+		/*
+		 * Add nixed User Space / System Server hooks
+		 */
+		// App widget manager
+		hookAll(XAppWidgetManager.getInstances(false), null, mSecret, false);
+
+		// Bluetooth adapater
+		hookAll(XBluetoothAdapter.getInstances(false), null, mSecret, false);
+
+		// Content resolver
+		hookAll(XContentResolver.getInstances(false), null, mSecret, false);
+
+		// Usage statistics manager
+		hookAll(XUsageStatsManager.getInstances(false), null, mSecret, false);
+
+		// Telephone service
+		hookAll(XTelephonyManager.getInstances(null, false), null, mSecret, false);
+
+		// SMS manager
+		hookAll(XSmsManager.getInstances(false), null, mSecret, false);
+		
+		// Account manager
+		hookAll(XAccountManager.getInstances(null, false), null, mSecret, false);
+		
+		// Package manager service
+		hookAll(XPackageManager.getInstances(null, false), null, mSecret, false);
+		
+		// Activity manager
+		hookAll(XActivityManager.getInstances(null, false), null, mSecret, false);
+		
+		// Clipboard manager
+		hookAll(XClipboardManager.getInstances(null, false), null, mSecret, false);
+		
+		/*
+		 * Add pure user space hooks
+		 */
+		
+		// Intent receive
+		hookAll(XActivityThread.getInstances(), null, mSecret, false);
+		
+		// Runtime
+		hookAll(XRuntime.getInstances(), null, mSecret, false);
+
+		// Application
+		hookAll(XApplication.getInstances(), null, mSecret, false);
+
+		// Audio record
+		hookAll(XAudioRecord.getInstances(), null, mSecret, false);
+
+		// Binder device
+		hookAll(XBinder.getInstances(), null, mSecret, false);
+
+		// Bluetooth device
+		hookAll(XBluetoothDevice.getInstances(), null, mSecret, false);
+
+		// Camera
+		hookAll(XCamera.getInstances(), null, mSecret, false);
+
+		// Camera2 device
+		hookAll(XCameraDevice2.getInstances(), null, mSecret, false);
+
+		// Connectivity manager
+		hookAll(XConnectivityManager.getInstances(null, true), null, mSecret, false);
+
+		// Context wrapper
+		hookAll(XContextImpl.getInstances(), null, mSecret, false);
+
+		// Environment
+		hookAll(XEnvironment.getInstances(), null, mSecret, false);
+
+		// Inet address
+		hookAll(XInetAddress.getInstances(), null, mSecret, false);
+
+		// Input device
+		hookAll(XInputDevice.getInstances(), null, mSecret, false);
+
+		// IO bridge
+		hookAll(XIoBridge.getInstances(), null, mSecret, false);
+
+		// IP prefix
+		hookAll(XIpPrefix.getInstances(), null, mSecret, false);
+
+		// Link properties
+		hookAll(XLinkProperties.getInstances(), null, mSecret, false);
+
+		// Location manager
+		hookAll(XLocationManager.getInstances(null, true), null, mSecret, false);
+
+		// Media recorder
+		hookAll(XMediaRecorder.getInstances(), null, mSecret, false);
+
+		// Network info
+		hookAll(XNetworkInfo.getInstances(), null, mSecret, false);
+
+		// Network interface
+		hookAll(XNetworkInterface.getInstances(), null, mSecret, false);
+
+		// NFC adapter
+		hookAll(XNfcAdapter.getInstances(), null, mSecret, false);
+
+		// Process
+		hookAll(XProcess.getInstances(), null, mSecret, false);
+
+		// Process builder
+		hookAll(XProcessBuilder.getInstances(), null, mSecret, false);
+
+		// Resources
+		hookAll(XResources.getInstances(), null, mSecret, false);
+
+		// Sensor manager
+		hookAll(XSensorManager.getInstances(null, true), null, mSecret, false);
+
+		// Settings secure
+		hookAll(XSettingsSecure.getInstances(), null, mSecret, false);
+
+		// SIP manager
+		hookAll(XSipManager.getInstances(), null, mSecret, false);
+
+		// System properties
+		hookAll(XSystemProperties.getInstances(), null, mSecret, false);
+
+		// USB device
+		hookAll(XUsbDevice.getInstances(), null, mSecret, false);
+
+		// Web view
+		hookAll(XWebView.getInstances(), null, mSecret, false);
+
+		// Window service
+		hookAll(XWindowManager.getInstances(null, true), null, mSecret, false);
+
+		// Wi-Fi service
+		hookAll(XWifiManager.getInstances(null, true), null, mSecret, false);
+
+		// Intent send
+		hookAll(XActivity.getInstances(), null, mSecret, false);
 	}
+	
+	private void bootstrapSystem(Object am, ClassLoader classLoader) throws Throwable {
+		/*
+		 * Register the XPrivacy service
+		 */
+		PrivacyService.register(mListHookError, null, mSecret, am);
+		
+		/*
+		 * Add nixed User Space / System Server hooks
+		 */
+		// App widget manager
+		hookAll(XAppWidgetManager.getInstances(true), null, mSecret, false);
 
-	private static void handleLoadPackage(String packageName, String processName, final ClassLoader classLoader,
-			boolean main, String secret) {
-		if (main && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && "android".equals(packageName)
-				&& "android".equals(processName))
-			try {
-				Class<?> cSystemServer = Class.forName("com.android.server.am.ActivityManagerService", false,
-						classLoader);
-				Method mMain = cSystemServer.getDeclaredMethod("setSystemProcess");
-				XposedBridge.hookMethod(mMain, new XC_MethodHook() {
-					@Override
-					protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
-						PrivacyService.register(mListHookError, classLoader, mSecret, param.thisObject);
-						hookAll(classLoader);
-					}
-				});
-			} catch (Throwable ex) {
-				Util.bug(null, ex);
-			}
+		// Bluetooth adapater
+		hookAll(XBluetoothAdapter.getInstances(true), null, mSecret, false);
 
+		// Content resolver
+		hookAll(XContentResolver.getInstances(true), null, mSecret, false);
+
+		// Usage statistics manager
+		hookAll(XUsageStatsManager.getInstances(true), null, mSecret, false);
+
+		// Telephone service
+		hookAll(XTelephonyManager.getInstances(null, true), null, mSecret, false);
+
+		// SMS manager
+		hookAll(XSmsManager.getInstances(true), null, mSecret, false);
+		
+		// Account manager
+		hookAll(XAccountManager.getInstances(null, true), null, mSecret, false);
+		
+		// Package manager service
+		hookAll(XPackageManager.getInstances(null, true), null, mSecret, false);
+		
+		// Activity manager
+		hookAll(XActivityManager.getInstances(null, true), null, mSecret, false);
+		
+		// Clipboard manager
+		hookAll(XClipboardManager.getInstances(null, true), null, mSecret, false);
+		
+		/*
+		 * Add pure system server hooks
+		 */
+
+		// Activity manager service
+		hookAll(XActivityManagerService.getInstances(), null, mSecret, false);
+		
+		// Intent firewall
+		hookAll(XIntentFirewall.getInstances(), null, mSecret, false);
+	}
+	
+	private void bootstrapPackage(String packageName, ClassLoader classLoader) {
 		// Skip hooking self
 		String self = XPrivacy.class.getPackage().getName();
 		if (packageName.equals(self)) {
-			hookAll(XUtilHook.getInstances(), classLoader, secret, false);
+			hookAll(XUtilHook.getInstances(), classLoader, mSecret, false);
 			return;
 		}
-
+		
 		// Build SERIAL
-		if (Process.myUid() != Process.SYSTEM_UID
-				&& PrivacyManager.getRestrictionExtra(null, Process.myUid(), PrivacyManager.cIdentification, "SERIAL",
-						null, Build.SERIAL, secret))
+		if (PrivacyManager.getRestrictionExtra(null, Process.myUid(), PrivacyManager.cIdentification, "SERIAL",
+						null, Build.SERIAL, mSecret))
 			try {
 				Field serial = Build.class.getField("SERIAL");
 				serial.setAccessible(true);
@@ -162,208 +350,69 @@ public class XPrivacy implements IXposedHookLoadPackage, IXposedHookZygoteInit {
 			} catch (Throwable ex) {
 				Util.bug(null, ex);
 			}
-
+		
 		// Activity recognition
 		try {
 			Class.forName("com.google.android.gms.location.ActivityRecognitionClient", false, classLoader);
-			hookAll(XActivityRecognitionClient.getInstances(), classLoader, secret, false);
+			hookAll(XActivityRecognitionClient.getInstances(), classLoader, mSecret, false);
 		} catch (Throwable ignored) {
 		}
 
 		// Advertising Id
 		try {
 			Class.forName("com.google.android.gms.ads.identifier.AdvertisingIdClient$Info", false, classLoader);
-			hookAll(XAdvertisingIdClientInfo.getInstances(), classLoader, secret, false);
+			hookAll(XAdvertisingIdClientInfo.getInstances(), classLoader, mSecret, false);
 		} catch (Throwable ignored) {
 		}
 
 		// Cast device
 		try {
 			Class.forName("com.google.android.gms.cast.CastDevice", false, classLoader);
-			hookAll(XCastDevice.getInstances(), classLoader, secret, false);
+			hookAll(XCastDevice.getInstances(), classLoader, mSecret, false);
 		} catch (Throwable ignored) {
 		}
 
 		// Google auth
 		try {
 			Class.forName("com.google.android.gms.auth.GoogleAuthUtil", false, classLoader);
-			hookAll(XGoogleAuthUtil.getInstances(), classLoader, secret, false);
+			hookAll(XGoogleAuthUtil.getInstances(), classLoader, mSecret, false);
 		} catch (Throwable ignored) {
 		}
 
 		// GoogleApiClient.Builder
 		try {
 			Class.forName("com.google.android.gms.common.api.GoogleApiClient$Builder", false, classLoader);
-			hookAll(XGoogleApiClient.getInstances(), classLoader, secret, false);
+			hookAll(XGoogleApiClient.getInstances(), classLoader, mSecret, false);
 		} catch (Throwable ignored) {
 		}
 
 		// Google Map V1
 		try {
 			Class.forName("com.google.android.maps.GeoPoint", false, classLoader);
-			hookAll(XGoogleMapV1.getInstances(), classLoader, secret, false);
+			hookAll(XGoogleMapV1.getInstances(), classLoader, mSecret, false);
 		} catch (Throwable ignored) {
 		}
 
 		// Google Map V2
 		try {
 			Class.forName("com.google.android.gms.maps.GoogleMap", false, classLoader);
-			hookAll(XGoogleMapV2.getInstances(), classLoader, secret, false);
+			hookAll(XGoogleMapV2.getInstances(), classLoader, mSecret, false);
 		} catch (Throwable ignored) {
 		}
 
 		// Location client
 		try {
 			Class.forName("com.google.android.gms.location.LocationClient", false, classLoader);
-			hookAll(XLocationClient.getInstances(), classLoader, secret, false);
+			hookAll(XLocationClient.getInstances(), classLoader, mSecret, false);
 		} catch (Throwable ignored) {
 		}
 
 		// Phone interface manager
 		if ("com.android.phone".equals(packageName))
-			hookAll(XTelephonyManager.getPhoneInstances(), classLoader, secret, false);
+			hookAll(XTelephonyManager.getPhoneInstances(), classLoader, mSecret, false);
 
 		// Providers
-		hookAll(XContentResolver.getPackageInstances(packageName, classLoader), classLoader, secret, false);
-	}
-	
-	private static void hookAll() {
-		// Intent receive
-		hookAll(XActivityThread.getInstances(), null, mSecret, false);
-	}
-
-	private static void hookAll(final ClassLoader classLoader) {
-		// Account manager
-		hookAll(XAccountManager.getInstances(null, true), classLoader, mSecret, false);
-
-		// Activity manager
-		hookAll(XActivityManager.getInstances(null, true), classLoader, mSecret, false);
-
-		// Activity manager service
-		hookAll(XActivityManagerService.getInstances(), classLoader, mSecret, false);
-
-		// App widget manager
-		hookAll(XAppWidgetManager.getInstances(), classLoader, mSecret, false);
-
-		// Application
-		hookAll(XApplication.getInstances(), classLoader, mSecret, false);
-
-		// Audio record
-		hookAll(XAudioRecord.getInstances(), classLoader, mSecret, false);
-
-		// Binder device
-		hookAll(XBinder.getInstances(), classLoader, mSecret, false);
-
-		// Bluetooth adapater
-		hookAll(XBluetoothAdapter.getInstances(), classLoader, mSecret, false);
-
-		// Bluetooth device
-		hookAll(XBluetoothDevice.getInstances(), classLoader, mSecret, false);
-
-		// Camera
-		hookAll(XCamera.getInstances(), classLoader, mSecret, false);
-
-		// Camera2 device
-		hookAll(XCameraDevice2.getInstances(), classLoader, mSecret, false);
-
-		// Clipboard manager
-		hookAll(XClipboardManager.getInstances(null, true), classLoader, mSecret, false);
-
-		// Connectivity manager
-		hookAll(XConnectivityManager.getInstances(null, true), classLoader, mSecret, false);
-
-		// Content resolver
-		hookAll(XContentResolver.getInstances(null), classLoader, mSecret, false);
-
-		// Context wrapper
-		hookAll(XContextImpl.getInstances(), classLoader, mSecret, false);
-
-		// Environment
-		hookAll(XEnvironment.getInstances(), classLoader, mSecret, false);
-
-		// Inet address
-		hookAll(XInetAddress.getInstances(), classLoader, mSecret, false);
-
-		// Input device
-		hookAll(XInputDevice.getInstances(), classLoader, mSecret, false);
-
-		// Intent firewall
-		hookAll(XIntentFirewall.getInstances(), classLoader, mSecret, false);
-
-		// IO bridge
-		hookAll(XIoBridge.getInstances(), classLoader, mSecret, false);
-
-		// IP prefix
-		hookAll(XIpPrefix.getInstances(), classLoader, mSecret, false);
-
-		// Link properties
-		hookAll(XLinkProperties.getInstances(), classLoader, mSecret, false);
-
-		// Location manager
-		hookAll(XLocationManager.getInstances(null, true), classLoader, mSecret, false);
-
-		// Media recorder
-		hookAll(XMediaRecorder.getInstances(), classLoader, mSecret, false);
-
-		// Network info
-		hookAll(XNetworkInfo.getInstances(), classLoader, mSecret, false);
-
-		// Network interface
-		hookAll(XNetworkInterface.getInstances(), classLoader, mSecret, false);
-
-		// NFC adapter
-		hookAll(XNfcAdapter.getInstances(), classLoader, mSecret, false);
-
-		// Package manager service
-		hookAll(XPackageManager.getInstances(null, true), classLoader, mSecret, false);
-
-		// Process
-		hookAll(XProcess.getInstances(), classLoader, mSecret, false);
-
-		// Process builder
-		hookAll(XProcessBuilder.getInstances(), classLoader, mSecret, false);
-
-		// Resources
-		hookAll(XResources.getInstances(), classLoader, mSecret, false);
-
-		// Runtime
-		hookAll(XRuntime.getInstances(), classLoader, mSecret, false);
-
-		// Sensor manager
-		hookAll(XSensorManager.getInstances(null, true), classLoader, mSecret, false);
-
-		// Settings secure
-		hookAll(XSettingsSecure.getInstances(), classLoader, mSecret, false);
-
-		// SIP manager
-		hookAll(XSipManager.getInstances(), classLoader, mSecret, false);
-
-		// SMS manager
-		hookAll(XSmsManager.getInstances(), classLoader, mSecret, false);
-
-		// System properties
-		hookAll(XSystemProperties.getInstances(), classLoader, mSecret, false);
-
-		// Telephone service
-		hookAll(XTelephonyManager.getInstances(null, true), classLoader, mSecret, false);
-
-		// Usage statistics manager
-		hookAll(XUsageStatsManager.getInstances(), classLoader, mSecret, false);
-
-		// USB device
-		hookAll(XUsbDevice.getInstances(), classLoader, mSecret, false);
-
-		// Web view
-		hookAll(XWebView.getInstances(), classLoader, mSecret, false);
-
-		// Window service
-		hookAll(XWindowManager.getInstances(null, true), classLoader, mSecret, false);
-
-		// Wi-Fi service
-		hookAll(XWifiManager.getInstances(null, true), classLoader, mSecret, false);
-
-		// Intent send
-		hookAll(XActivity.getInstances(), classLoader, mSecret, false);
+		hookAll(XContentResolver.getPackageInstances(packageName, classLoader), classLoader, mSecret, false);
 	}
 
 	public static void handleGetSystemService(String name, String className, String secret) {
@@ -408,14 +457,21 @@ public class XPrivacy implements IXposedHookLoadPackage, IXposedHookZygoteInit {
 	}
 
 	private static void hook(final XHook hook, ClassLoader classLoader, String secret) {
+		boolean doLog = PrivacyManager.cShell.equals(hook.getRestrictionName());
+		
+		if(doLog)Log.d("TESTING", "Core: Adding hook " + hook.getRestrictionName() + "[" + hook.getSpecifier() + "]");
+		
 		// Get meta data
 		Hook md = PrivacyManager.getHook(hook.getRestrictionName(), hook.getSpecifier());
 		if (md == null) {
 			String message = "Not found hook=" + hook;
 			mListHookError.add(message);
 			Util.log(hook, Log.ERROR, message);
-		} else if (!md.isAvailable())
+		} else if (!md.isAvailable()) {
+			if(doLog)Log.d("TESTING", "Core: Hook could not be applied!");
+			
 			return;
+		}
 
 		// Provide secret
 		if (secret == null)
@@ -428,6 +484,8 @@ public class XPrivacy implements IXposedHookLoadPackage, IXposedHookZygoteInit {
 			try {
 				hookClass = findClass(hook.getClassName(), classLoader);
 			} catch (Throwable ex) {
+				if(doLog)Log.d("TESTING", "Core: Class could not be found!");
+				
 				String message = "Class not found hook=" + hook;
 				int level = (md != null && md.isOptional() ? Log.WARN : Log.ERROR);
 				if ("isXposedEnabled".equals(hook.getMethodName()))
@@ -482,6 +540,8 @@ public class XPrivacy implements IXposedHookLoadPackage, IXposedHookZygoteInit {
 					}
 					clazz = clazz.getSuperclass();
 				} catch (Throwable ex) {
+					if(doLog)Log.d("TESTING", "Core: Method could not be found!");
+					
 					if (ex.getClass().equals(ClassNotFoundException.class)
 							|| ex.getClass().equals(NoClassDefFoundError.class))
 						break;
@@ -492,19 +552,27 @@ public class XPrivacy implements IXposedHookLoadPackage, IXposedHookZygoteInit {
 			// Hook members
 			for (Member member : listMember)
 				try {
+					if(doLog)Log.d("TESTING", "Core: Hooking method '" + member.getName() + "'");
+					
 					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
 						if ((member.getModifiers() & Modifier.NATIVE) != 0)
 							Util.log(hook, Log.WARN, "Native method=" + member);
 					XposedBridge.hookMethod(member, new XMethodHook(hook));
 				} catch (NoSuchFieldError ex) {
+					if(doLog)Log.d("TESTING", "Core: Method could not be hooked! '" + member.getName() + "'");
+					
 					Util.log(hook, Log.WARN, ex.toString());
 				} catch (Throwable ex) {
+					if(doLog)Log.d("TESTING", "Core: Method could not be hooked! '" + member.getName() + "'");
+					
 					mListHookError.add(ex.toString());
 					Util.bug(hook, ex);
 				}
 
 			// Check if members found
 			if (listMember.isEmpty() && !hook.getClassName().startsWith("com.google.android.gms")) {
+				if(doLog)Log.d("TESTING", "Core: Method could not be hooked! (Empty method list)");
+				
 				String message = "Method not found hook=" + hook;
 				int level = (md != null && md.isOptional() ? Log.WARN : Log.ERROR);
 				if ("isXposedEnabled".equals(hook.getMethodName()))
@@ -515,6 +583,8 @@ public class XPrivacy implements IXposedHookLoadPackage, IXposedHookZygoteInit {
 				Util.logStack(hook, level);
 			}
 		} catch (Throwable ex) {
+			if(doLog)Log.d("TESTING", "Core: Hook could not be applied! (Exception ex)");
+			
 			mListHookError.add(ex.toString());
 			Util.bug(hook, ex);
 		}

--- a/src/biz/bokhorst/xprivacy/XSmsManager.java
+++ b/src/biz/bokhorst/xprivacy/XSmsManager.java
@@ -47,19 +47,21 @@ public class XSmsManager extends XHook {
 	};
 	// @formatter:on
 
-	public static List<XHook> getInstances() {
+	public static List<XHook> getInstances(boolean services) {
 		List<XHook> listHook = new ArrayList<XHook>();
-		listHook.add(new XSmsManager(Methods.getAllMessagesFromIcc, PrivacyManager.cMessages));
-		listHook.add(new XSmsManager(Methods.getCarrierConfigValues, PrivacyManager.cMessages));
-		listHook.add(new XSmsManager(Methods.sendDataMessage, PrivacyManager.cCalling));
-		listHook.add(new XSmsManager(Methods.sendMultimediaMessage, PrivacyManager.cCalling));
-		listHook.add(new XSmsManager(Methods.sendMultipartTextMessage, PrivacyManager.cCalling));
-		listHook.add(new XSmsManager(Methods.sendTextMessage, PrivacyManager.cCalling));
-
-		listHook.add(new XSmsManager(Methods.Srv_getAllMessagesFromIccEf, PrivacyManager.cMessages));
-		listHook.add(new XSmsManager(Methods.Srv_sendData, PrivacyManager.cCalling));
-		listHook.add(new XSmsManager(Methods.Srv_sendMultipartText, PrivacyManager.cCalling));
-		listHook.add(new XSmsManager(Methods.Srv_sendText, PrivacyManager.cCalling));
+		if (!services) {
+			listHook.add(new XSmsManager(Methods.getAllMessagesFromIcc, PrivacyManager.cMessages));
+			listHook.add(new XSmsManager(Methods.getCarrierConfigValues, PrivacyManager.cMessages));
+			listHook.add(new XSmsManager(Methods.sendDataMessage, PrivacyManager.cCalling));
+			listHook.add(new XSmsManager(Methods.sendMultimediaMessage, PrivacyManager.cCalling));
+			listHook.add(new XSmsManager(Methods.sendMultipartTextMessage, PrivacyManager.cCalling));
+			listHook.add(new XSmsManager(Methods.sendTextMessage, PrivacyManager.cCalling));
+		} else {
+			listHook.add(new XSmsManager(Methods.Srv_getAllMessagesFromIccEf, PrivacyManager.cMessages));
+			listHook.add(new XSmsManager(Methods.Srv_sendData, PrivacyManager.cCalling));
+			listHook.add(new XSmsManager(Methods.Srv_sendMultipartText, PrivacyManager.cCalling));
+			listHook.add(new XSmsManager(Methods.Srv_sendText, PrivacyManager.cCalling));
+		}
 		return listHook;
 	}
 

--- a/src/biz/bokhorst/xprivacy/XTelephonyManager.java
+++ b/src/biz/bokhorst/xprivacy/XTelephonyManager.java
@@ -155,40 +155,41 @@ public class XTelephonyManager extends XHook {
 		if (!cClassName.equals(className)) {
 			if (className == null)
 				className = cClassName;
+			
+			if (!server) {
+				listHook.add(new XTelephonyManager(Methods.disableLocationUpdates, null, className));
+				listHook.add(new XTelephonyManager(Methods.enableLocationUpdates, PrivacyManager.cLocation, className));
+				listHook.add(new XTelephonyManager(Methods.getAllCellInfo, PrivacyManager.cLocation, className));
+				listHook.add(new XTelephonyManager(Methods.getCellLocation, PrivacyManager.cLocation, className));
+	
+				listHook.add(new XTelephonyManager(Methods.getDeviceId, PrivacyManager.cPhone, className));
+				listHook.add(new XTelephonyManager(Methods.getGroupIdLevel1, PrivacyManager.cPhone, className));
+				listHook.add(new XTelephonyManager(Methods.getIsimDomain, PrivacyManager.cPhone, className));
+				listHook.add(new XTelephonyManager(Methods.getIsimImpi, PrivacyManager.cPhone, className));
+				listHook.add(new XTelephonyManager(Methods.getIsimImpu, PrivacyManager.cPhone, className));
+				listHook.add(new XTelephonyManager(Methods.getLine1AlphaTag, PrivacyManager.cPhone, className));
+				listHook.add(new XTelephonyManager(Methods.getLine1Number, PrivacyManager.cPhone, className));
+				listHook.add(new XTelephonyManager(Methods.getMsisdn, PrivacyManager.cPhone, className));
+	
+				listHook.add(new XTelephonyManager(Methods.getNeighboringCellInfo, PrivacyManager.cLocation, className));
+	
+				listHook.add(new XTelephonyManager(Methods.getSimSerialNumber, PrivacyManager.cPhone, className));
+				listHook.add(new XTelephonyManager(Methods.getSubscriberId, PrivacyManager.cPhone, className));
+				listHook.add(new XTelephonyManager(Methods.getVoiceMailAlphaTag, PrivacyManager.cPhone, className));
+				listHook.add(new XTelephonyManager(Methods.getVoiceMailNumber, PrivacyManager.cPhone, className));
+	
+				listHook.add(new XTelephonyManager(Methods.listen, PrivacyManager.cLocation, className));
+				listHook.add(new XTelephonyManager(Methods.listen, PrivacyManager.cPhone, className));
+	
+				// No permissions required
+				listHook.add(new XTelephonyManager(Methods.getNetworkCountryIso, PrivacyManager.cPhone, className));
+				listHook.add(new XTelephonyManager(Methods.getNetworkOperator, PrivacyManager.cPhone, className));
+				listHook.add(new XTelephonyManager(Methods.getNetworkOperatorName, PrivacyManager.cPhone, className));
+				listHook.add(new XTelephonyManager(Methods.getSimCountryIso, PrivacyManager.cPhone, className));
+				listHook.add(new XTelephonyManager(Methods.getSimOperator, PrivacyManager.cPhone, className));
+				listHook.add(new XTelephonyManager(Methods.getSimOperatorName, PrivacyManager.cPhone, className));
 
-			listHook.add(new XTelephonyManager(Methods.disableLocationUpdates, null, className));
-			listHook.add(new XTelephonyManager(Methods.enableLocationUpdates, PrivacyManager.cLocation, className));
-			listHook.add(new XTelephonyManager(Methods.getAllCellInfo, PrivacyManager.cLocation, className));
-			listHook.add(new XTelephonyManager(Methods.getCellLocation, PrivacyManager.cLocation, className));
-
-			listHook.add(new XTelephonyManager(Methods.getDeviceId, PrivacyManager.cPhone, className));
-			listHook.add(new XTelephonyManager(Methods.getGroupIdLevel1, PrivacyManager.cPhone, className));
-			listHook.add(new XTelephonyManager(Methods.getIsimDomain, PrivacyManager.cPhone, className));
-			listHook.add(new XTelephonyManager(Methods.getIsimImpi, PrivacyManager.cPhone, className));
-			listHook.add(new XTelephonyManager(Methods.getIsimImpu, PrivacyManager.cPhone, className));
-			listHook.add(new XTelephonyManager(Methods.getLine1AlphaTag, PrivacyManager.cPhone, className));
-			listHook.add(new XTelephonyManager(Methods.getLine1Number, PrivacyManager.cPhone, className));
-			listHook.add(new XTelephonyManager(Methods.getMsisdn, PrivacyManager.cPhone, className));
-
-			listHook.add(new XTelephonyManager(Methods.getNeighboringCellInfo, PrivacyManager.cLocation, className));
-
-			listHook.add(new XTelephonyManager(Methods.getSimSerialNumber, PrivacyManager.cPhone, className));
-			listHook.add(new XTelephonyManager(Methods.getSubscriberId, PrivacyManager.cPhone, className));
-			listHook.add(new XTelephonyManager(Methods.getVoiceMailAlphaTag, PrivacyManager.cPhone, className));
-			listHook.add(new XTelephonyManager(Methods.getVoiceMailNumber, PrivacyManager.cPhone, className));
-
-			listHook.add(new XTelephonyManager(Methods.listen, PrivacyManager.cLocation, className));
-			listHook.add(new XTelephonyManager(Methods.listen, PrivacyManager.cPhone, className));
-
-			// No permissions required
-			listHook.add(new XTelephonyManager(Methods.getNetworkCountryIso, PrivacyManager.cPhone, className));
-			listHook.add(new XTelephonyManager(Methods.getNetworkOperator, PrivacyManager.cPhone, className));
-			listHook.add(new XTelephonyManager(Methods.getNetworkOperatorName, PrivacyManager.cPhone, className));
-			listHook.add(new XTelephonyManager(Methods.getSimCountryIso, PrivacyManager.cPhone, className));
-			listHook.add(new XTelephonyManager(Methods.getSimOperator, PrivacyManager.cPhone, className));
-			listHook.add(new XTelephonyManager(Methods.getSimOperatorName, PrivacyManager.cPhone, className));
-
-			if (server) {
+			} else {
 				// PhoneSubInfo
 				listHook.add(new XTelephonyManager(Methods.Srv_getDeviceId, PrivacyManager.cPhone, Srv.SubInfo));
 				listHook.add(new XTelephonyManager(Methods.Srv_getGroupIdLevel1, PrivacyManager.cPhone, Srv.SubInfo));

--- a/src/biz/bokhorst/xprivacy/XUsageStatsManager.java
+++ b/src/biz/bokhorst/xprivacy/XUsageStatsManager.java
@@ -49,16 +49,18 @@ public class XUsageStatsManager extends XHook {
 
 	// @formatter:on
 
-	public static List<XHook> getInstances() {
+	public static List<XHook> getInstances(boolean services) {
 		List<XHook> listHook = new ArrayList<XHook>();
-		listHook.add(new XUsageStatsManager(Methods.queryAndAggregateUsageStats, PrivacyManager.cSystem));
-		listHook.add(new XUsageStatsManager(Methods.queryConfigurations, PrivacyManager.cSystem));
-		listHook.add(new XUsageStatsManager(Methods.queryEvents, PrivacyManager.cSystem));
-		listHook.add(new XUsageStatsManager(Methods.queryUsageStats, PrivacyManager.cSystem));
-
-		listHook.add(new XUsageStatsManager(Methods.Srv_queryConfigurationStats, PrivacyManager.cSystem));
-		listHook.add(new XUsageStatsManager(Methods.Srv_queryEvents, PrivacyManager.cSystem));
-		listHook.add(new XUsageStatsManager(Methods.Srv_queryUsageStats, PrivacyManager.cSystem));
+		if (!services) {
+			listHook.add(new XUsageStatsManager(Methods.queryAndAggregateUsageStats, PrivacyManager.cSystem));
+			listHook.add(new XUsageStatsManager(Methods.queryConfigurations, PrivacyManager.cSystem));
+			listHook.add(new XUsageStatsManager(Methods.queryEvents, PrivacyManager.cSystem));
+			listHook.add(new XUsageStatsManager(Methods.queryUsageStats, PrivacyManager.cSystem));
+		} else {
+			listHook.add(new XUsageStatsManager(Methods.Srv_queryConfigurationStats, PrivacyManager.cSystem));
+			listHook.add(new XUsageStatsManager(Methods.Srv_queryEvents, PrivacyManager.cSystem));
+			listHook.add(new XUsageStatsManager(Methods.Srv_queryUsageStats, PrivacyManager.cSystem));
+		}
 		return listHook;
 	}
 


### PR DESCRIPTION
Just ignorer the commit from yesterday, forgot to merge up before continuing working on it.

From the testing that I have done on my own Lollipop device, this seams to fix things and get most of it working. When I say most of it, I of cause mean that this does not fix the Native issues with Xposed Framework on Lollipop, but that is not an issue with the module so it does not really mater here. 

I also added some consistency between Lollipop and Pre-Lollipop ROM's. This change has been tested by me on Android 4.1, 4.3 and 5.1 AOSP/CM ROM's using the appropriate Xposed versions. The technique used in XPrivacy.java to create the consistency have however been tested on many other devices, as I use this in my own module. 

Not sure if you want to add your own structure and such to this, in which case this should provide you with the idea of how to make it work. But in any case, the current code will run on your supported devices, including Lollipop, with the exception of the Native hooks, if used with unsupported Xposed versions.