### PR TITLE
Anchor adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,8 +509,8 @@ If desired, you can even restrict XPrivacy from accessing any of the above,
 but there are some [limitations](#limitations).
 
 Please note that any Xposed module has basically root permissions and therefore can circumvent any Android permission.
-<a name="frequently-asked-questions"></a>
-Frequently Asked Questions (FAQ)
+
+<a name="frequently-asked-questions"></a>Frequently Asked Questions (FAQ)
 --------------------------------
 
 <a name="FAQ1"></a>
@@ -1440,7 +1440,7 @@ I do not recommend using XPrivacy in combination with any of the similar solutio
 I need all my time developing XPrivacy, so I will not test XPrivacy along side any of the similar solutions.
 If you test XPrivacy along side any of the similar solutions, you can probably help others by reporting your test results.
 
-In The Media
+<a name="news"></a>In The Media
 ------------
 
 * [Manage Individual App Permissions with XPrivacy](http://www.xda-developers.com/android/manage-individual-app-permissions-with-xprivacy/) (June 20, 2013)


### PR DESCRIPTION
The Github markdown system allows anchors on the same line as headings, so I moved the FAQ anchor onto the same line as the header.

I also added a *news* anchor for the *In The Media* section.  The *news* heading was confusing because the user may have expected to read news from the developer regarding XPrivacy in that section (which was not the case).  Although it will now work either way, you may want to change the *News* link in XDA post 1 to read *In The Media*.  At the same time, you can add a *Screenshots* link in XDA post 1, if you desire.