### PR TITLE
Improved "Toggle filter" menu item

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -34,7 +34,7 @@
     <string name="menu_clear_all">Clear all</string>
     <string name="menu_clear_usage">Clear</string>
     <string name="menu_clear_db">Clear all XPrivacy data</string>
-    <string name="menu_usage_all">Toggle filter</string>
+    <string name="menu_usage_all">Toggle all/restricted</string>
     <string name="menu_apply">Apply template</string>
     <string name="menu_clear">Clear</string>
     <string name="menu_app_launch">Launch</string>


### PR DESCRIPTION
The *Toggle filter* menu item has always been less than ideal.  The menu presented one level higher has *Filters*, but this toggle has nothing to do with those filters.  It's confusing.

This menu item toggles between showing all usage data, and showing only restricted usage data.  How about we name it accordingly?  I've changed it to *Toggle all/restricted* to indicate the actual function.

Another choice is *Toggle restricted-only*.

(Ideally, the menu item would change from *Show restricted only* (or *Hide non-restricted*) to *Show all* depending on the state, but that would require a coding change.)

(Note that the change of adding the EOL to the end of the file is something that GitHub did automatically.)